### PR TITLE
Fix windows babel path bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,7 @@
-#!/usr/bin/env node --harmony
-var path = require( "path" );
-var dir = path.basename( __dirname ); // directory this file is in
+#!/usr/bin/env node
 
 require( "babel-register" )( {
 	ignore: false,
-	only: new RegExp( path.join( dir, "src" ) )
+	only: /src/
 } );
 require( "./src/index.js" );


### PR DESCRIPTION
The nested path was causing issues with windows. I tried escaping the string with [`_.escapeRegExp`](https://lodash.com/docs#escapeRegExp), but that didn't seem to help either. 

Removing the `__dirname` and just using `src` seemed to work for both mac and windows. Hopefully it'll work when it is published to `npm` as well.