### PR TITLE
Move babel-plugin-rewire to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
+    "babel-plugin-rewire": "1.0.0-rc-4",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-stage-0": "^6.3.13",
     "babel-preset-stage-2": "^6.3.13",
@@ -58,7 +59,6 @@
   "devDependencies": {
     "ava": "^0.15.0",
     "babel-eslint": "^5.0.0-beta6",
-    "babel-plugin-rewire": "1.0.0-rc-4",
     "eslint": "^1.10.3",
     "eslint-config-leankit": "^1.1.0",
     "jscs": "^3.0.4",


### PR DESCRIPTION
This should be a patch version (bug fix). The current version (`v4.0.0`) is broken because of this and will not work for whoever tries to install it.