### PR TITLE
Fix upstream/develop branch detection on windows

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,9 @@
 {
   "presets": [ "es2015", "stage-0" ],
-  "plugins": [ "babel-plugin-rewire" ],
-  "sourceMaps": "inline"
+  "sourceMaps": "inline",
+  "env": {
+    "test": {
+      "plugins": [ "babel-plugin-rewire" ]
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
   "scripts": {
     "lint": "jscs ./ && eslint --ignore-path .gitignore ./",
     "lint:fix": "jscs --fix ./ && eslint --fix --ignore-path .gitignore ./",
-    "test": "ava 'test/**/*.js' --require ./test/helpers/setup.js",
-    "test:nyan": "ava 'test/**/*.js' --require ./test/helpers/setup.js --tap | tap-nyan",
+    "test": "BABEL_ENV=test ava 'test/**/*.js' --require ./test/helpers/setup.js",
+    "test:nyan": "npm test -- --tap | tap-nyan",
     "test:watch": "npm test -- --watch",
     "cover": "nyc --reporter=text --reporter=html --check-coverage --statements 97.62 --branches 95.92 --functions 100 --lines 97.62 npm test",
-    "cover:watch": "onchange 'src/**/*.js' 'test/**/*.js' -- npm run test:cover",
+    "cover:watch": "onchange 'src/**/*.js' 'test/**/*.js' -- npm run cover",
     "cover:open": "open coverage/index.html",
     "pre-commit": "echo 'Running pre-commit hooks...' && exit 0"
   },
@@ -32,7 +32,6 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "babel-plugin-rewire": "1.0.0-rc-4",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-stage-0": "^6.3.13",
     "babel-preset-stage-2": "^6.3.13",
@@ -59,6 +58,7 @@
   "devDependencies": {
     "ava": "^0.15.0",
     "babel-eslint": "^5.0.0-beta6",
+    "babel-plugin-rewire": "1.0.0-rc-4",
     "eslint": "^1.10.3",
     "eslint-config-leankit": "^1.1.0",
     "jscs": "^3.0.4",

--- a/src/sequence-steps.js
+++ b/src/sequence-steps.js
@@ -52,9 +52,11 @@ export function gitFetchUpstreamMaster( [ git, options ] ) {
 }
 
 export function gitBranchGrepUpstreamDevelop( [ git, options ] ) {
-	const command = `git branch -r | grep "upstream/develop"`;
+	const command = `git branch -r`;
 	return utils.exec( command ).then( data => {
-		options.develop = true;
+		const branches = data.split( "\n" );
+		const hasDevelop = branches.some( branch => ~branch.trim().indexOf( "upstream/develop" ) );
+		options.develop = hasDevelop;
 	} ).catch( data => {
 		options.develop = false;
 	} );


### PR DESCRIPTION
In addition to fixing the detection code in windows this also moves around the `babel-plugin-rewire` so that it is only a dev dependency and only needed for the `test` environment, which was causing node `v0.12.x` warnings when installing `tag-release`.

This PR closes issues #26 and #23 