### PR TITLE
Changing up tag-release to support other json config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Usage: tag-release [options]
 Options:
 
   -h, --help                     Output usage information
+  -c, --config [filePath] Path to JSON Configuration file (defaults to './package.json')
   -r, --release [type]           Release type (major, minor, patch)
   --verbose                      Console additional information
   -v                             Console the version of tag-release
@@ -40,6 +41,8 @@ Options:
 Examples:
 
    $ tag-release
+   $ tag-release --config ../../config.json
+   $ tag-release -c ./manifest.json
    $ tag-release --release major
    $ tag-release -r minor
    $ tag-release --verbose

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,7 @@ const questions = {
 
 commander
 	.option( "-r, --release [type]", "Release type (major, minor, patch, premajor, preminor, prepatch, prerelease)", /^(major|minor|patch|premajor|preminor|prepatch|prerelease)/i )
+	.option( "-c, --config [filePath]", "Path to JSON Configuration file ( Defaults to './package.json' )", /^.*\.json$/ )
 	.option( "--verbose", "Console additional information" )
 	.option( "-v", "Console the version of tag-release" )
 	.option( "-p, --prerelease", "Create a pre-release" )
@@ -36,6 +37,8 @@ commander
 commander.on( "--help", () => {
 	console.log( "Examples: \n" );
 	console.log( "   $ tag-release" );
+	console.log( "   $ tag-release --config ../../config.json" );
+	console.log( "   $ tag-release -c ./manifest.json" );
 	console.log( "   $ tag-release --release major" );
 	console.log( "   $ tag-release -r minor" );
 	console.log( "   $ tag-release --verbose" );

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ const questions = {
 
 commander
 	.option( "-r, --release [type]", "Release type (major, minor, patch, premajor, preminor, prepatch, prerelease)", /^(major|minor|patch|premajor|preminor|prepatch|prerelease)/i )
-	.option( "-c, --config [filePath]", "Path to JSON Configuration file ( Defaults to './package.json' )", /^.*\.json$/ )
+	.option( "-c, --config [filePath]", "Path to JSON Configuration file (defaults to './package.json')", /^.*\.json$/ )
 	.option( "--verbose", "Console additional information" )
 	.option( "-v", "Console the version of tag-release" )
 	.option( "-p, --prerelease", "Create a pre-release" )
@@ -68,6 +68,7 @@ export function startTagRelease( options, queries = questions.general ) {
 	}
 
 	options = _.extend( {}, commander, options );
+	options.configPath = options.config || "./package.json";
 
 	return tagRelease( options );
 }

--- a/src/sequence-steps.js
+++ b/src/sequence-steps.js
@@ -246,16 +246,18 @@ export function updateLog( [ git, options ] ) {
 
 export function updateVersion( [ git, options ] ) {
 	let packageJson = {};
+	const configPath = options.config ? options.config : "./package.json";
+
 	try {
-		packageJson = utils.readJSONFile( "./package.json" );
+		packageJson = utils.readJSONFile( configPath );
 	} catch ( e ) {
 		utils.advise( "updateVersion" );
 	}
-	const oldVersion = options.currentVersion;
+	const oldVersion = packageJson.version;
 	const newVersion = packageJson.version = semver.inc( oldVersion, options.release, options.identifier );
-	utils.writeJSONFile( "./package.json", packageJson );
+	utils.writeJSONFile( configPath, packageJson );
 	options.versions = { oldVersion, newVersion };
-	logger.log( chalk.green( `Updated package.json from ${ oldVersion } to ${ newVersion }` ) );
+	logger.log( chalk.green( `Updated ${ configPath } from ${ oldVersion } to ${ newVersion }` ) );
 }
 
 export function updateChangelog( [ git, options ] ) {
@@ -277,7 +279,8 @@ export function updateChangelog( [ git, options ] ) {
 }
 
 export function gitDiff( [ git, options ] ) {
-	const command = "git diff --color CHANGELOG.md package.json";
+	const configPath = options.config ? options.config : "./package.json";
+	const command = `git diff --color CHANGELOG.md ${ configPath }`;
 	return utils.exec( command )
 		.then( data => {
 			logger.log( data );
@@ -298,9 +301,10 @@ export function gitDiff( [ git, options ] ) {
 }
 
 export function gitAdd( [ git, options ] ) {
-	const command = "git add CHANGELOG.md package.json";
+	const configPath = options.config ? options.config : "./package.json";
+	const command = `git add CHANGELOG.md ${ configPath }`;
 	utils.log.begin( command );
-	return nodefn.lift( ::git.add )( [ "CHANGELOG.md", "package.json" ] )
+	return nodefn.lift( ::git.add )( [ "CHANGELOG.md", configPath ] )
 		.then( () => utils.log.end() );
 }
 

--- a/src/sequence-steps.js
+++ b/src/sequence-steps.js
@@ -340,10 +340,11 @@ export function gitPushUpstreamFeatureBranch( [ git, options ] ) {
 }
 
 export function npmPublish( [ git, options ] ) {
+	const configPath = options.config ? options.config : "./package.json";
 	const command = `npm publish`;
 
-	if ( !utils.isPackagePrivate() ) {
-		return utils.getPackageRegistry().then( registry => {
+	if ( !utils.isPackagePrivate( configPath ) ) {
+		return utils.getPackageRegistry( configPath ).then( registry => {
 			return utils.prompt( [ {
 				type: "confirm",
 				name: "publish",

--- a/src/utils.js
+++ b/src/utils.js
@@ -73,12 +73,12 @@ export default {
 			} );
 		} );
 	},
-	isPackagePrivate() {
-		const pkg = this.readJSONFile( "./package.json" );
+	isPackagePrivate( configPath ) {
+		const pkg = this.readJSONFile( configPath );
 		return !!pkg.private;
 	},
-	getPackageRegistry() {
-		const pkg = this.readJSONFile( "./package.json" );
+	getPackageRegistry( configPath ) {
+		const pkg = this.readJSONFile( configPath );
 		const registry = get( pkg, "publishConfig.registry" );
 
 		if ( registry ) {

--- a/test/sequence-steps/get-current-branch-version.js
+++ b/test/sequence-steps/get-current-branch-version.js
@@ -20,7 +20,7 @@ test.afterEach( t => {
 } );
 
 test.serial( "getCurrentBranchVersion calls readJSONFile", t => {
-	getCurrentBranchVersion( [ git, {} ] );
+	getCurrentBranchVersion( [ git, { configPath: "./package.json" } ] );
 	t.truthy( utils.readJSONFile.calledWith( "./package.json" ) );
 } );
 

--- a/test/sequence-steps/update-version.js
+++ b/test/sequence-steps/update-version.js
@@ -36,7 +36,7 @@ test.afterEach( t => {
 } );
 
 test.serial( "updateVersion calls readJSONFile", t => {
-	updateVersion( [ git, { release: "minor" } ] );
+	updateVersion( [ git, { configPath: "./package.json", release: "minor" } ] );
 	t.truthy( utils.readJSONFile.calledWith( "./package.json" ) );
 } );
 
@@ -53,7 +53,7 @@ test.serial( "updateVersion passes options.release to semver.inc", t => {
 } );
 
 test.serial( "updateVersion calls writeJSONFile", t => {
-	updateVersion( [ git, { release: "minor" } ] );
+	updateVersion( [ git, { configPath: "./package.json", release: "minor" } ] );
 	t.truthy( utils.writeJSONFile.calledWith( "./package.json", { version: "1.1.0" } ) );
 } );
 
@@ -64,13 +64,13 @@ test.serial( "updateVersion gives advise when utils.readJSONFile fails", t => {
 } );
 
 test.serial( "updateVersion correctly reads non default JSON config file", t => {
-	const options = { release: "minor", config: "./manifest.json" };
+	const options = { release: "minor", configPath: "./manifest.json" };
 	updateVersion( [ git, options ] );
-	t.truthy( utils.readJSONFile.calledWith( options.config ) );
+	t.truthy( utils.readJSONFile.calledWith( options.configPath ) );
 } );
 
 test.serial( "updateVersion correctly updates non default config file", t => {
-	const options = { release: "minor", config: "./manifest.json" };
+	const options = { release: "minor", configPath: "./manifest.json" };
 	updateVersion( [ git, options ] );
-	t.truthy( utils.writeJSONFile.calledWith( options.config, { version: "1.1.0" } ) );
+	t.truthy( utils.writeJSONFile.calledWith( options.configPath, { version: "1.1.0" } ) );
 } );

--- a/test/sequence-steps/update-version.js
+++ b/test/sequence-steps/update-version.js
@@ -62,3 +62,15 @@ test.serial( "updateVersion gives advise when utils.readJSONFile fails", t => {
 	updateVersion( [ git, { release: "minor" } ] );
 	t.truthy( utils.advise.called );
 } );
+
+test.serial( "updateVersion correctly reads non default JSON config file", t => {
+	const options = { release: "minor", config: "./manifest.json" };
+	updateVersion( [ git, options ] );
+	t.truthy( utils.readJSONFile.calledWith( options.config ) );
+} );
+
+test.serial( "updateVersion correctly updates non default config file", t => {
+	const options = { release: "minor", config: "./manifest.json" };
+	updateVersion( [ git, options ] );
+	t.truthy( utils.writeJSONFile.calledWith( options.config, { version: "1.1.0" } ) );
+} );


### PR DESCRIPTION
Check out #38 for more info on the why.

This change adds in support for the user to be able to define (optionally) whether they want to specify a JSON file to use instead of being bound to only the package.json .
