### PR TITLE
Feature reset

### DIFF
--- a/src/advise.js
+++ b/src/advise.js
@@ -45,7 +45,13 @@ You might consider reseting your develop by running 'git reset --hard upstream/d
 
 It could be that your local environment is out of sync with your upstream or you are missing a upstream feature branch.
 
-You might consider reseting your branch by running 'git reset --hard upstream/develop' or creating a upstream feature branch.`
+You might consider reseting your branch by running 'git reset --hard upstream/develop' or creating a upstream feature branch.`,
+	gitStash: `It looks like you had some uncommited changes. We went ahead and stashed them so you don't lose any of your work.`,
+	gitUpstream: `It appears we couldn't access your remote upstream repository.
+
+tag-release needs an upstream remote in order to work correctly. You can double check by running 'git remote -v'
+
+To add a remote run 'git remote add upstream https://github.com/owner/repo.git'`
 };
 const MAXIMUM_WIDTH = 50;
 

--- a/src/advise.js
+++ b/src/advise.js
@@ -46,7 +46,7 @@ You might consider reseting your develop by running 'git reset --hard upstream/d
 It could be that your local environment is out of sync with your upstream or you are missing a upstream feature branch.
 
 You might consider reseting your branch by running 'git reset --hard upstream/develop' or creating a upstream feature branch.`,
-	gitStash: `It looks like you had some uncommited changes. We went ahead and stashed them so you don't lose any of your work.`,
+	gitStash: "It looks like you had some uncommited changes. We went ahead and stashed them so you don't lose any of your work.",
 	gitUpstream: `It appears we couldn't access your remote upstream repository.
 
 tag-release needs an upstream remote in order to work correctly. You can double check by running 'git remote -v'

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,8 @@ commander
 	.option( "--verbose", "Console additional information" )
 	.option( "-v", "Console the version of tag-release" )
 	.option( "-p, --prerelease", "Create a pre-release" )
-	.option( "-i, --identifier <identifier>", "Identifier used for pre-release" );
+	.option( "-i, --identifier <identifier>", "Identifier used for pre-release" )
+	.option( "--reset", "Reset repo to upstream master/develop branches." );
 
 commander.on( "--help", () => {
 	console.log( "Examples: \n" );
@@ -44,6 +45,7 @@ commander.on( "--help", () => {
 	console.log( "   $ tag-release --verbose" );
 	console.log( "   $ tag-release -v" );
 	console.log( "   $ tag-release -i rc" );
+	console.log( "   $ tag-release --reset" );
 } );
 
 commander.on( "-v", () => {

--- a/src/sequence-steps.js
+++ b/src/sequence-steps.js
@@ -476,8 +476,9 @@ export function verifyDevelopBranch( [ git, options ] ) {
 
 export function verifyBranch( [ git, options ] ) {
 	const command = `git branch --list ${ options.branch }`;
+	utils.log.begin( command );
 	return utils.exec( command ).then( data => {
-		const branches = data.split( "\n" ).filter( String ); // Remove empty array entry
+		const branches = data.split( "\n" ).filter( String );
 		const exists = branches.length;
 		if ( !exists ) {
 			const createCommand = `git branch ${ options.branch } upstream/${ options.branch }`;
@@ -490,22 +491,16 @@ export function verifyBranch( [ git, options ] ) {
 	} );
 }
 
-export function gitCheckoutBranch( [ git, options ] ) {
-	const command = `git checkout ${ options.branch }`;
-	utils.log.begin( command );
-	return nodefn.lift( ::git.checkout )( `${ options.branch }` )
-		.then( () => utils.log.end() );
-}
-
 export function gitStash( [ git, options ] ) {
-	const co = `git diff-index HEAD --`;
-	return utils.exec( co )
+	const command = `git diff-index HEAD --`;
+	utils.log.begin( command );
+	return utils.exec( command )
 		.then( data => {
 			utils.log.end();
 			if ( data ) {
-				const command = `git stash`;
-				utils.log.begin( command );
-				return utils.exec( command )
+				const stashCommand = `git stash`;
+				utils.log.begin( stashCommand );
+				return utils.exec( stashCommand )
 					.then( result => {
 						utils.log.end();
 						utils.advise( "gitStash", { exit: false } );

--- a/src/sequence-steps.js
+++ b/src/sequence-steps.js
@@ -40,7 +40,7 @@ const preReleaseSteps = [
 	gitFetchUpstreamMaster,
 	getCurrentBranchVersion,
 	askPrereleaseIdentifier,
-	getFeatureBranch,
+	getCurrentBranch,
 	gitMergeUpstreamBranch,
 	gitLog,
 	previewLog,
@@ -56,6 +56,18 @@ const preReleaseSteps = [
 	npmPublish,
 	githubUpstream,
 	githubRelease
+];
+
+const resetSteps = [
+	gitFetchUpstreamMaster,
+	gitBranchGrepUpstreamDevelop,
+	gitStash,
+	verifyMasterBranch,
+	gitCheckoutMaster,
+	gitResetBranch,
+	verifyDevelopBranch,
+	gitCheckoutDevelop,
+	gitResetBranch
 ];
 
 export function getCurrentBranchVersion( [ git, options ] ) {
@@ -116,7 +128,7 @@ export function gitCheckoutMaster( [ git, options ] ) {
 		.then( () => utils.log.end() );
 }
 
-export function getFeatureBranch( [ git, options ] ) {
+export function getCurrentBranch( [ git, options ] ) {
 	const command = "git rev-parse --abbrev-ref HEAD";
 	utils.log.begin( command );
 	return utils.exec( command ).then( branch => {
@@ -444,4 +456,63 @@ export function githubRelease( [ git, options ] ) {
 	} );
 }
 
-export { releaseSteps, preReleaseSteps };
+export function gitResetBranch( [ git, options ] ) {
+	const command = `git reset --hard upstream/${ options.branch }`;
+	utils.log.begin( command );
+	return utils.exec( command )
+		.then( data => utils.log.end() )
+		.catch( error => utils.advise( "gitUpstream" ) );
+}
+
+export function verifyMasterBranch( [ git, options ] ) {
+	options.branch = "master";
+	return verifyBranch( [ git, options ] );
+}
+
+export function verifyDevelopBranch( [ git, options ] ) {
+	options.branch = "develop";
+	return verifyBranch( [ git, options ] );
+}
+
+export function verifyBranch( [ git, options ] ) {
+	const command = `git branch --list ${ options.branch }`;
+	return utils.exec( command ).then( data => {
+		const branches = data.split( "\n" ).filter( String ); // Remove empty array entry
+		const exists = branches.length;
+		if ( !exists ) {
+			const createCommand = `git branch ${ options.branch } upstream/${ options.branch }`;
+			utils.log.begin( createCommand );
+			return utils.exec( createCommand )
+				.then( result => utils.log.end() )
+				.catch( error => utils.advise( "gitUpstream" ) );
+		}
+		return Promise.resolve();
+	} );
+}
+
+export function gitCheckoutBranch( [ git, options ] ) {
+	const command = `git checkout ${ options.branch }`;
+	utils.log.begin( command );
+	return nodefn.lift( ::git.checkout )( `${ options.branch }` )
+		.then( () => utils.log.end() );
+}
+
+export function gitStash( [ git, options ] ) {
+	const co = `git diff-index HEAD --`;
+	return utils.exec( co )
+		.then( data => {
+			utils.log.end();
+			if ( data ) {
+				const command = `git stash`;
+				utils.log.begin( command );
+				return utils.exec( command )
+					.then( result => {
+						utils.log.end();
+						utils.advise( "gitStash", { exit: false } );
+					} );
+			}
+			return Promise.resolve();
+		} );
+}
+
+export { releaseSteps, preReleaseSteps, resetSteps };

--- a/src/tag-release.js
+++ b/src/tag-release.js
@@ -2,12 +2,17 @@
 
 import simpleGitFactory from "simple-git";
 import sequence from "when/sequence";
-import { releaseSteps, preReleaseSteps } from "./sequence-steps";
+import { releaseSteps, preReleaseSteps, resetSteps } from "./sequence-steps";
 
 export default options => {
 	const git = simpleGitFactory( "." );
+	let steps = [];
 
-	const steps = options.prerelease ? preReleaseSteps : releaseSteps;
+	if ( options.reset ) {
+		steps = resetSteps;
+	} else {
+		steps = options.prerelease ? preReleaseSteps : releaseSteps;
+	}
 
 	sequence( steps, [ git, options ] ).then( () => console.log( "Finished" ) );
 };

--- a/test/sequence-steps/get-current-branch.js
+++ b/test/sequence-steps/get-current-branch.js
@@ -10,7 +10,7 @@ const utils = {
 	exec: sinon.spy( command => new Promise( resolve => resolve( "feature-branch" ) ) )
 };
 
-import { getFeatureBranch, __RewireAPI__ as RewireAPI } from "../../src/sequence-steps";
+import { getCurrentBranch, __RewireAPI__ as RewireAPI } from "../../src/sequence-steps";
 
 test.beforeEach( t => {
 	RewireAPI.__Rewire__( "utils", utils );
@@ -20,28 +20,28 @@ test.afterEach( t => {
 	RewireAPI.__ResetDependency__( "utils" );
 } );
 
-test.serial( "getFeatureBranch calls log.begin", t => {
-	return getFeatureBranch( [ git, {} ] ).then( () => {
+test.serial( "getCurrentBranch calls log.begin", t => {
+	return getCurrentBranch( [ git, {} ] ).then( () => {
 		t.truthy( utils.log.begin.called );
 	} );
 } );
 
-test.serial( "getFeatureBranch calls utils.exec with command", t => {
+test.serial( "getCurrentBranch calls utils.exec with command", t => {
 	const COMMAND = "git rev-parse --abbrev-ref HEAD";
-	return getFeatureBranch( [ git, {} ] ).then( () => {
+	return getCurrentBranch( [ git, {} ] ).then( () => {
 		t.truthy( utils.exec.calledWith( COMMAND ) );
 	} );
 } );
 
-test.serial( "getFeatureBranch sets options.branch to current branch", t => {
+test.serial( "getCurrentBranch sets options.branch to current branch", t => {
 	const options = { branch: undefined };
-	return getFeatureBranch( [ git, options ] ).then( () => {
+	return getCurrentBranch( [ git, options ] ).then( () => {
 		t.is( options.branch, "feature-branch" );
 	} );
 } );
 
-test.serial( "getFeatureBranch calls log.end", t => {
-	return getFeatureBranch( [ git, {} ] ).then( () => {
+test.serial( "getCurrentBranch calls log.end", t => {
+	return getCurrentBranch( [ git, {} ] ).then( () => {
 		t.truthy( utils.log.end.called );
 	} );
 } );

--- a/test/sequence-steps/git-reset-branch.js
+++ b/test/sequence-steps/git-reset-branch.js
@@ -1,0 +1,60 @@
+import test from "ava";
+import sinon from "sinon";
+import nodefn from "when/node";
+import { git } from "../helpers/index.js";
+
+const utils = {
+	log: {
+		begin: sinon.spy(),
+		end: sinon.spy()
+	},
+	advise: sinon.spy(),
+	exec: sinon.spy( command => new Promise( resolve => resolve() ) )
+};
+const lift = sinon.spy( nodefn, "lift" );
+const options = { branch: "develop" };
+
+import { gitResetBranch, __RewireAPI__ as RewireAPI } from "../../src/sequence-steps";
+
+test.beforeEach( t => {
+	RewireAPI.__Rewire__( "utils", utils );
+	RewireAPI.__Rewire__( "nodefn", { lift } );
+} );
+
+test.afterEach( t => {
+	RewireAPI.__ResetDependency__( "utils" );
+	RewireAPI.__ResetDependency__( "nodefn" );
+} );
+
+test.serial( "gitResetBranch calls log.begin", t => {
+	return gitResetBranch( [ git, options ] ).then( () => {
+		t.truthy( utils.log.begin.called );
+	} );
+} );
+
+test.serial( "gitResetBranch calls exec", t => {
+	return gitResetBranch( [ git, options ] ).then( () => {
+		t.truthy( utils.exec.calledWith( "git reset --hard upstream/develop" ) );
+	} );
+} );
+
+test.serial( "gitResetBranch calls log.end", t => {
+	return gitResetBranch( [ git, options ] ).then( () => {
+		t.truthy( utils.log.end.called );
+	} );
+} );
+
+test.serial( "gitResetBranch gives advise when utils.exec fails", t => {
+	const myUtils = {
+		log: {
+			begin: sinon.spy(),
+			end: sinon.spy()
+		},
+		exec: sinon.spy( command => Promise.reject() ),
+		advise: sinon.spy()
+	};
+	RewireAPI.__Rewire__( "utils", myUtils );
+	return gitResetBranch( [ git, {} ] ).then( () => {
+		t.truthy( myUtils.advise.calledWith( "gitUpstream" ) );
+	} );
+} );

--- a/test/sequence-steps/git-stash.js
+++ b/test/sequence-steps/git-stash.js
@@ -1,0 +1,79 @@
+import test from "ava";
+import sinon from "sinon";
+import { git, isPromise } from "../helpers/index.js";
+
+let utils = null;
+
+import { gitStash, __RewireAPI__ as RewireAPI } from "../../src/sequence-steps";
+
+test.beforeEach( t => {
+	utils = {
+		log: {
+			begin: sinon.spy(),
+			end: sinon.spy()
+		},
+		advise: sinon.spy(),
+		exec: sinon.spy( command => new Promise( resolve => resolve( "data" ) ) )
+	};
+	RewireAPI.__Rewire__( "utils", utils );
+} );
+
+test.afterEach( t => {
+	RewireAPI.__ResetDependency__( "utils" );
+} );
+
+test.serial( "gitStash returns a promise", t => {
+	const promise = gitStash( [ git, {} ] );
+	t.truthy( isPromise( promise ) );
+} );
+
+test.serial( "gitStash calls log.begin", t => {
+	return gitStash( [ git, {} ] ).then( () => {
+		t.truthy( utils.log.begin.calledWith( "git diff-index HEAD --" ) );
+	} );
+} );
+
+test.serial( "gitStash calls exec", t => {
+	return gitStash( [ git, {} ] ).then( () => {
+		t.truthy( utils.exec.calledWith( "git diff-index HEAD --" ) );
+	} );
+} );
+
+test.serial( "gitStash calls log.end", t => {
+	return gitStash( [ git, {} ] ).then( () => {
+		t.truthy( utils.log.end.called );
+	} );
+} );
+
+test.serial( "gitStash calls log.begin for git stash command", t => {
+	return gitStash( [ git, {} ] ).then( () => {
+		t.truthy( utils.log.begin.calledWith( "git stash" ) );
+	} );
+} );
+
+test.serial( "gitStash calls exec for git stash command", t => {
+	return gitStash( [ git, {} ] ).then( () => {
+		t.truthy( utils.exec.calledWith( "git stash" ) );
+	} );
+} );
+
+test.serial( "gitStash should not call exec for git stash command with no data", t => {
+	utils = {
+		log: {
+			begin: sinon.spy(),
+			end: sinon.spy()
+		},
+		advise: sinon.spy(),
+		exec: sinon.spy( command => new Promise( resolve => resolve( ) ) )
+	};
+	RewireAPI.__Rewire__( "utils", utils );
+	return gitStash( [ git, {} ] ).then( () => {
+		t.falsy( utils.exec.calledWith( "git stash" ) );
+	} );
+} );
+
+test.serial( "gitStash gives advise when there are changes to stash", t => {
+	return gitStash( [ git, {} ] ).then( () => {
+		t.truthy( utils.advise.calledWith( "gitStash" ) );
+	} );
+} );

--- a/test/sequence-steps/verify-branch.js
+++ b/test/sequence-steps/verify-branch.js
@@ -1,0 +1,86 @@
+import test from "ava";
+import sinon from "sinon";
+import "sinon-as-promised";
+import { git, isPromise } from "../helpers/index.js";
+
+const utils = {
+	log: {
+		begin: sinon.spy(),
+		end: sinon.spy()
+	},
+	advise: sinon.spy(),
+	exec: sinon.spy( command => new Promise( resolve => resolve( "\n" ) ) )
+};
+const options = { branch: "feature-branch" };
+
+import { verifyBranch, __RewireAPI__ as RewireAPI } from "../../src/sequence-steps";
+
+test.beforeEach( t => {
+	RewireAPI.__Rewire__( "utils", utils );
+} );
+
+test.afterEach( t => {
+	RewireAPI.__ResetDependency__( "utils" );
+} );
+
+test.serial( "verifyBranch returns a promise", t => {
+	const promise = verifyBranch( [ git, options ] );
+	t.truthy( isPromise( promise ) );
+} );
+
+test.serial( "verifyBranch calls log.begin", t => {
+	return verifyBranch( [ git, options ] ).then( () => {
+		t.truthy( utils.log.begin.calledWith( "git branch --list feature-branch" ) );
+	} );
+} );
+
+test.serial( "verifyBranch calls exec", t => {
+	return verifyBranch( [ git, options ] ).then( () => {
+		t.truthy( utils.exec.calledWith( "git branch --list feature-branch" ) );
+	} );
+} );
+
+test.serial( "verifyBranch calls log.begin when branch doesn't exist", t => {
+	return verifyBranch( [ git, options ] ).then( () => {
+		t.truthy( utils.log.begin.calledWith( "git branch feature-branch upstream/feature-branch" ) );
+	} );
+} );
+
+test.serial( "verifyBranch calls exec when branch doesn't exist", t => {
+	return verifyBranch( [ git, options ] ).then( () => {
+		t.truthy( utils.exec.calledWith( "git branch feature-branch upstream/feature-branch" ) );
+	} );
+} );
+
+test.serial( "verifyBranch gives advise when branching fails", t => {
+	const execStub = sinon.stub();
+	execStub.onCall( 0 ).returns( new Promise( resolve => resolve( "\n" ) ) );
+	execStub.onCall( 1 ).returns( Promise.reject() );
+	const myUtils = {
+		log: {
+			begin: sinon.spy(),
+			end: sinon.spy()
+		},
+		advise: sinon.spy(),
+		exec: execStub
+	};
+	RewireAPI.__Rewire__( "utils", myUtils );
+	return verifyBranch( [ git, {} ] ).then( () => {
+		t.truthy( myUtils.advise.calledWith( "gitUpstream" ) );
+	} );
+} );
+
+test.serial( "verifyBranch should not call exec when branch exists", t => {
+	const myUtils = {
+		log: {
+			begin: sinon.spy(),
+			end: sinon.spy()
+		},
+		advise: sinon.spy(),
+		exec: sinon.spy( command => new Promise( resolve => resolve( "feature-branch" ) ) )
+	};
+	RewireAPI.__Rewire__( "utils", myUtils );
+	return verifyBranch( [ git, {} ] ).then( () => {
+		t.falsy( myUtils.exec.calledWith( "git branch feature-branch upstream/feature-branch" ) );
+	} );
+} );

--- a/test/sequence-steps/verify-develop-branch.js
+++ b/test/sequence-steps/verify-develop-branch.js
@@ -1,0 +1,86 @@
+import test from "ava";
+import sinon from "sinon";
+import "sinon-as-promised";
+import { git, isPromise } from "../helpers/index.js";
+
+const utils = {
+	log: {
+		begin: sinon.spy(),
+		end: sinon.spy()
+	},
+	advise: sinon.spy(),
+	exec: sinon.spy( command => new Promise( resolve => resolve( "\n" ) ) )
+};
+const options = { branch: "develop" };
+
+import { verifyDevelopBranch, __RewireAPI__ as RewireAPI } from "../../src/sequence-steps";
+
+test.beforeEach( t => {
+	RewireAPI.__Rewire__( "utils", utils );
+} );
+
+test.afterEach( t => {
+	RewireAPI.__ResetDependency__( "utils" );
+} );
+
+test.serial( "verifyDevelopBranch returns a promise", t => {
+	const promise = verifyDevelopBranch( [ git, options ] );
+	t.truthy( isPromise( promise ) );
+} );
+
+test.serial( "verifyDevelopBranch calls log.begin", t => {
+	return verifyDevelopBranch( [ git, options ] ).then( () => {
+		t.truthy( utils.log.begin.calledWith( "git branch --list develop" ) );
+	} );
+} );
+
+test.serial( "verifyDevelopBranch calls exec", t => {
+	return verifyDevelopBranch( [ git, options ] ).then( () => {
+		t.truthy( utils.exec.calledWith( "git branch --list develop" ) );
+	} );
+} );
+
+test.serial( "verifyDevelopBranch calls log.begin when branch doesn't exist", t => {
+	return verifyDevelopBranch( [ git, options ] ).then( () => {
+		t.truthy( utils.log.begin.calledWith( "git branch develop upstream/develop" ) );
+	} );
+} );
+
+test.serial( "verifyDevelopBranch calls exec when branch doesn't exist", t => {
+	return verifyDevelopBranch( [ git, options ] ).then( () => {
+		t.truthy( utils.exec.calledWith( "git branch develop upstream/develop" ) );
+	} );
+} );
+
+test.serial( "verifyDevelopBranch gives advise when branching fails", t => {
+	const execStub = sinon.stub();
+	execStub.onCall( 0 ).returns( new Promise( resolve => resolve( "\n" ) ) );
+	execStub.onCall( 1 ).returns( Promise.reject() );
+	const myUtils = {
+		log: {
+			begin: sinon.spy(),
+			end: sinon.spy()
+		},
+		advise: sinon.spy(),
+		exec: execStub
+	};
+	RewireAPI.__Rewire__( "utils", myUtils );
+	return verifyDevelopBranch( [ git, {} ] ).then( () => {
+		t.truthy( myUtils.advise.calledWith( "gitUpstream" ) );
+	} );
+} );
+
+test.serial( "verifyDevelopBranch should not call exec when branch exists", t => {
+	const myUtils = {
+		log: {
+			begin: sinon.spy(),
+			end: sinon.spy()
+		},
+		advise: sinon.spy(),
+		exec: sinon.spy( command => new Promise( resolve => resolve( "develop" ) ) )
+	};
+	RewireAPI.__Rewire__( "utils", myUtils );
+	return verifyDevelopBranch( [ git, {} ] ).then( () => {
+		t.falsy( myUtils.exec.calledWith( "git branch develop upstream/develop" ) );
+	} );
+} );

--- a/test/sequence-steps/verify-master-branch.js
+++ b/test/sequence-steps/verify-master-branch.js
@@ -1,0 +1,86 @@
+import test from "ava";
+import sinon from "sinon";
+import "sinon-as-promised";
+import { git, isPromise } from "../helpers/index.js";
+
+const utils = {
+	log: {
+		begin: sinon.spy(),
+		end: sinon.spy()
+	},
+	advise: sinon.spy(),
+	exec: sinon.spy( command => new Promise( resolve => resolve( "\n" ) ) )
+};
+const options = { branch: "master" };
+
+import { verifyMasterBranch, __RewireAPI__ as RewireAPI } from "../../src/sequence-steps";
+
+test.beforeEach( t => {
+	RewireAPI.__Rewire__( "utils", utils );
+} );
+
+test.afterEach( t => {
+	RewireAPI.__ResetDependency__( "utils" );
+} );
+
+test.serial( "verifyMasterBranch returns a promise", t => {
+	const promise = verifyMasterBranch( [ git, options ] );
+	t.truthy( isPromise( promise ) );
+} );
+
+test.serial( "verifyMasterBranch calls log.begin", t => {
+	return verifyMasterBranch( [ git, options ] ).then( () => {
+		t.truthy( utils.log.begin.calledWith( "git branch --list master" ) );
+	} );
+} );
+
+test.serial( "verifyMasterBranch calls exec", t => {
+	return verifyMasterBranch( [ git, options ] ).then( () => {
+		t.truthy( utils.exec.calledWith( "git branch --list master" ) );
+	} );
+} );
+
+test.serial( "verifyMasterBranch calls log.begin when branch doesn't exist", t => {
+	return verifyMasterBranch( [ git, options ] ).then( () => {
+		t.truthy( utils.log.begin.calledWith( "git branch master upstream/master" ) );
+	} );
+} );
+
+test.serial( "verifyMasterBranch calls exec when branch doesn't exist", t => {
+	return verifyMasterBranch( [ git, options ] ).then( () => {
+		t.truthy( utils.exec.calledWith( "git branch master upstream/master" ) );
+	} );
+} );
+
+test.serial( "verifyMasterBranch gives advise when branching fails", t => {
+	const execStub = sinon.stub();
+	execStub.onCall( 0 ).returns( new Promise( resolve => resolve( "\n" ) ) );
+	execStub.onCall( 1 ).returns( Promise.reject() );
+	const myUtils = {
+		log: {
+			begin: sinon.spy(),
+			end: sinon.spy()
+		},
+		advise: sinon.spy(),
+		exec: execStub
+	};
+	RewireAPI.__Rewire__( "utils", myUtils );
+	return verifyMasterBranch( [ git, {} ] ).then( () => {
+		t.truthy( myUtils.advise.calledWith( "gitUpstream" ) );
+	} );
+} );
+
+test.serial( "verifyMasterBranch should not call exec when branch exists", t => {
+	const myUtils = {
+		log: {
+			begin: sinon.spy(),
+			end: sinon.spy()
+		},
+		advise: sinon.spy(),
+		exec: sinon.spy( command => new Promise( resolve => resolve( "master" ) ) )
+	};
+	RewireAPI.__Rewire__( "utils", myUtils );
+	return verifyMasterBranch( [ git, {} ] ).then( () => {
+		t.falsy( myUtils.exec.calledWith( "git branch master upstream/master" ) );
+	} );
+} );


### PR DESCRIPTION
Added an intelligent --reset flag that'll rest hard the master branch and develop if one exists.

The --reset flag should handle both scenarios

It will reset the environment for master and/or develop after a failed or canceled tag-release session

It will get a repo in the correct state after a repo is first cloned.

Example: cloned repo, but doesn't have master or develop branches locally
The idea behind the --reset flag is that if something goes wrong a dev/ops person can just run tag-release --reset to get into a good state.

Existing methods should be able to be reused, but additional methods will need to be created.

This addresses issue #44 