### PR TITLE
Feature fetch upstream and several bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,15 @@ Usage: tag-release [options]
 Options:
 
   -h, --help                     Output usage information
-  -c, --config [filePath] Path to JSON Configuration file (defaults to './package.json')
+  -c, --config [filePath]        Path to JSON Configuration file (defaults to './package.json')
   -r, --release [type]           Release type (major, minor, patch)
   --verbose                      Console additional information
-  -v                             Console the version of tag-release
+  -V, --version                  output the version number
   -p, --prerelease               Create a pre-release
   -i, --identifier <identifier>  Identifier used for pre-release
+  --reset                        Reset repo to upstream master/develop branches
+	--promote [tag]                Promotes specified pre-release tag to an offical release
+	--continue                     Continues the rebase process of a tag promotion
 
 Examples:
 
@@ -46,9 +49,15 @@ Examples:
    $ tag-release --release major
    $ tag-release -r minor
    $ tag-release --verbose
-   $ tag-release -v
+   $ tag-release -V
+   $ tag-release --version
+   $ tag-release --prerelease
    $ tag-release -p
    $ tag-release -p -i foo
+   $ tag-release --reset
+   $ tag-release --promote
+   $ tag-release --promote v1.1.1-my-tagged-version.0
+   $ tag-release --continue
 ```
 
 ### Pre-releases
@@ -103,6 +112,42 @@ These tags always match the following schema: [version]-[identifier].[bump]
 | 1.2.3          | 2.0.0-pre.0       | major   | yes           | pre (default) | 2.0.0-pre.1    |
 | 1.2.3          | 2.0.0-pre.1       | minor   | no            | N/A           | 1.3.0          |
 | 1.3.0          | 2.0.0-pre.1       | minor   | yes           | filter        | 1.4.0-filter.0 |
+
+### Pre-release Promotion
+
+This feature is use for promoting a pre-release to an offical release that is intended to go out
+into production. In order use this feature will you have to provide `tag-release` with the
+`--promote` as a command-line flag.
+
+```
+Usage:
+   $ tag-release --promote
+
+Example:
+
+   $ tag-release --promote
+   ? Select the pre-release you wish to promote: (Use arrow keys)
+   > v1.1.1-blah.0
+     v2.0.0-another.1
+     v3.0.0-this.5
+```
+
+After selecting the tag you wish to promote it will attempt remove all pre-release commits from history
+and rebase it with master. If conflicts arise you will be promoted to fix the conflicts and then continue
+with the promotion process by running `tag-release --continue`. This cycle will continue until all conflicts
+are resolve and then it will flow as a normal release from that point on.
+
+The `--promote` feature also allows for an optional command-line argument of a tag in the follow form:
+
+```
+Example:
+
+   $ tag-release --promote v1.1.1-feature.2
+   $ tag-release --promote 1.1.1-feature.2 # v is optional for tag
+```
+
+This will skip the selection process of a tag you wish to promote and it will flow the same flow as the
+normal `--promote` command-line argument above.
 
 ### GitHub Integration
 

--- a/specs/git.spec.js
+++ b/specs/git.spec.js
@@ -90,10 +90,11 @@ describe( "git", () => {
 				expectedRunCommandArgs: { args: "branch -r" }
 			},
 			fetch: {
-				expectedRunCommandArgs: { args: "fetch upstream master --tags" }
+				expectedRunCommandArgs: { args: "fetch upstream --tags" }
 			},
-			fetchUpstreamMaster: {
-				expectedRunCommandArgs: { args: "fetch upstream master --tags", failHelpKey: "gitFetchUpstreamMaster" }
+			fetchUpstream: {
+				args: "gitFetchUpstream",
+				expectedRunCommandArgs: { args: "fetch upstream --tags", failHelpKey: "gitFetchUpstream" }
 			},
 			checkout: {
 				args: "test-branch",
@@ -241,13 +242,6 @@ describe( "git", () => {
 				return git.checkout( "test-branch", "test-key" ).then( () => {
 					expect( git.runCommand ).toHaveBeenCalledTimes( 1 );
 					expect( git.runCommand ).toHaveBeenCalledWith( { args: "checkout test-branch", failHelpKey: "test-key" } );
-				} );
-			} );
-
-			it( "should call `git.fetch` without tags when specified", () => {
-				return git.fetch( "test-branch", false ).then( () => {
-					expect( git.runCommand ).toHaveBeenCalledTimes( 1 );
-					expect( git.runCommand ).toHaveBeenCalledWith( { args: "fetch upstream test-branch" } );
 				} );
 			} );
 

--- a/specs/git.spec.js
+++ b/specs/git.spec.js
@@ -121,7 +121,7 @@ describe( "git", () => {
 				expectedRunCommandArgs: { args: "merge upstream/master --ff-only" }
 			},
 			mergeUpstreamDevelop: {
-				expectedRunCommandArgs: { args: "merge upstream/develop --no-ff" }
+				expectedRunCommandArgs: { args: "merge upstream/develop --ff-only" }
 			},
 			mergePromotionBranch: {
 				args: "v1.1.1-feature.0",
@@ -134,7 +134,7 @@ describe( "git", () => {
 				expectedRunCommandArgs: { args: "tag --sort=v:refname", logMessage: "Getting list of tags" }
 			},
 			shortLog: {
-				expectedRunCommandArgs: { args: "--no-pager log --no-merges --date-order --pretty=format:\"%s\"", logMessage: "Parsing git log" }
+				expectedRunCommandArgs: { args: `--no-pager log --no-merges --date-order --pretty=format:"%s"`, logMessage: "Parsing git log" }
 			},
 			diff: {
 				args: [ "CHANGELOG.md", "package.json" ],
@@ -146,7 +146,7 @@ describe( "git", () => {
 			},
 			commit: {
 				args: "This is a test commit",
-				expectedRunCommandArgs: { args: "commit -m \"This is a test commit\"" }
+				expectedRunCommandArgs: { args: `commit -m "This is a test commit"` }
 			},
 			tag: {
 				args: "v1.0.0",
@@ -195,7 +195,7 @@ describe( "git", () => {
 			},
 			generateRebaseCommitLog: {
 				args: "v1.1.1-blah.0",
-				expectedRunCommandArgs: { args: "log upstream/master..HEAD --pretty=format:\"%h %s\" --no-merges" }
+				expectedRunCommandArgs: { args: `log upstream/master..HEAD --pretty=format:"%h %s" --no-merges` }
 			},
 			rebaseUpstreamMaster: {
 				expectedRunCommandArgs: { args: "rebase upstream/master" }
@@ -248,7 +248,7 @@ describe( "git", () => {
 			it( "should call `git.shortLog` with the appropriate options when a tag is given", () => {
 				return git.shortLog( "v1.2.3" ).then( () => {
 					expect( git.runCommand ).toHaveBeenCalledTimes( 1 );
-					expect( git.runCommand ).toHaveBeenCalledWith( { args: "--no-pager log --no-merges --date-order --pretty=format:\"%s\" v1.2.3..", logMessage: "Parsing git log" } );
+					expect( git.runCommand ).toHaveBeenCalledWith( { args: `--no-pager log --no-merges --date-order --pretty=format:"%s" v1.2.3..`, logMessage: "Parsing git log" } );
 				} );
 			} );
 

--- a/specs/git.spec.js
+++ b/specs/git.spec.js
@@ -134,7 +134,7 @@ describe( "git", () => {
 				expectedRunCommandArgs: { args: "tag --sort=v:refname", logMessage: "Getting list of tags" }
 			},
 			shortLog: {
-				expectedRunCommandArgs: { args: "--no-pager log --no-merges --date-order --pretty=format:'%s'", logMessage: "Parsing git log" }
+				expectedRunCommandArgs: { args: "--no-pager log --no-merges --date-order --pretty=format:\"%s\"", logMessage: "Parsing git log" }
 			},
 			diff: {
 				args: [ "CHANGELOG.md", "package.json" ],
@@ -195,7 +195,7 @@ describe( "git", () => {
 			},
 			generateRebaseCommitLog: {
 				args: "v1.1.1-blah.0",
-				expectedRunCommandArgs: { args: "log upstream/master..HEAD --pretty=format:'%h %s' --no-merges" }
+				expectedRunCommandArgs: { args: "log upstream/master..HEAD --pretty=format:\"%h %s\" --no-merges" }
 			},
 			rebaseUpstreamMaster: {
 				expectedRunCommandArgs: { args: "rebase upstream/master" }
@@ -248,7 +248,7 @@ describe( "git", () => {
 			it( "should call `git.shortLog` with the appropriate options when a tag is given", () => {
 				return git.shortLog( "v1.2.3" ).then( () => {
 					expect( git.runCommand ).toHaveBeenCalledTimes( 1 );
-					expect( git.runCommand ).toHaveBeenCalledWith( { args: "--no-pager log --no-merges --date-order --pretty=format:'%s' v1.2.3..", logMessage: "Parsing git log" } );
+					expect( git.runCommand ).toHaveBeenCalledWith( { args: "--no-pager log --no-merges --date-order --pretty=format:\"%s\" v1.2.3..", logMessage: "Parsing git log" } );
 				} );
 			} );
 

--- a/specs/workflows/steps.spec.js
+++ b/specs/workflows/steps.spec.js
@@ -57,12 +57,12 @@ describe( "shared workflow steps", () => {
 		} );
 	} );
 
-	describe( "gitFetchUpstreamMaster", () => {
-		it( "should return the result of `git.fetchUpstreamMaster`", () => {
-			git.fetchUpstreamMaster = jest.fn( () => Promise.resolve() );
+	describe( "gitFetchUpstream", () => {
+		it( "should return the result of `git.fetchUpstream`", () => {
+			git.fetchUpstream = jest.fn( () => Promise.resolve() );
 
-			return run.gitFetchUpstreamMaster( state ).then( () => {
-				expect( git.fetchUpstreamMaster ).toHaveBeenCalledTimes( 1 );
+			return run.gitFetchUpstream( state ).then( () => {
+				expect( git.fetchUpstream ).toHaveBeenCalledTimes( 1 );
 			} );
 		} );
 	} );

--- a/src/advise.js
+++ b/src/advise.js
@@ -4,7 +4,7 @@ const MESSAGES = {
 	gitCommandFailed: `Ooops. Hhmmm...that didn't work very well.
 
 You really shouldn't be seeing this message, so, if you are, ping someone in engineering to see if they can help you figure out what went wrong.`,
-	gitFetchUpstreamMaster: `It looks like git couldn't fetch your upstream.
+	gitFetchUpstream: `It looks like git couldn't fetch your upstream.
 
 tag-release needs an upstream remote in order to work correctly. You can double check by running 'git remote -v'
 

--- a/src/git.js
+++ b/src/git.js
@@ -76,7 +76,7 @@ const git = {
 	},
 
 	mergeUpstreamDevelop() {
-		return git.merge( "upstream/develop", false );
+		return git.merge( "upstream/develop" );
 	},
 
 	mergePromotionBranch( tag ) {

--- a/src/git.js
+++ b/src/git.js
@@ -122,7 +122,7 @@ const git = {
 	},
 
 	shortLog( tag ) {
-		let args = `--no-pager log --no-merges --date-order --pretty=format:'%s'`;
+		let args = `--no-pager log --no-merges --date-order --pretty=format:"%s"`;
 		args = ( tag && tag.length ) ? `${ args } ${ tag }..` : args;
 		return git.runCommand( { args, logMessage: "Parsing git log" } );
 	},
@@ -208,7 +208,7 @@ const git = {
 	generateRebaseCommitLog( tag ) {
 		tag = tag.slice( 1, tag.lastIndexOf( "." ) ); // remove the 'v' and version of pre-release that it is eg. .0, .1, .2, etc...
 
-		const args = `log upstream/master..HEAD --pretty=format:'%h %s' --no-merges`;
+		const args = `log upstream/master..HEAD --pretty=format:"%h %s" --no-merges`;
 		return git.runCommand( { args } ).then( result => {
 			let commits = result.split( "\n" );
 

--- a/src/git.js
+++ b/src/git.js
@@ -35,13 +35,13 @@ const git = {
 		return git.runCommand( { args } );
 	},
 
-	fetch( branch = "master", includeTags = true, failHelpKey ) {
-		const args = `fetch upstream ${ branch }${ includeTags ? " --tags" : "" }`;
+	fetch( failHelpKey ) {
+		const args = `fetch upstream --tags`;
 		return git.runCommand( ( failHelpKey && failHelpKey.length ) ? { args, failHelpKey } : { args } );
 	},
 
-	fetchUpstreamMaster() {
-		return git.fetch( "master", true, "gitFetchUpstreamMaster" );
+	fetchUpstream() {
+		return git.fetch( "gitFetchUpstream" );
 	},
 
 	checkout( branch, failHelpKey ) {

--- a/src/index.js
+++ b/src/index.js
@@ -27,10 +27,10 @@ const questions = {
 };
 
 commander
+	.version( pkg.version )
 	.option( "-r, --release [type]", "Release type (major, minor, patch, premajor, preminor, prepatch, prerelease)", /^(major|minor|patch|premajor|preminor|prepatch|prerelease)/i )
 	.option( "-c, --config [filePath]", "Path to JSON Configuration file (defaults to './package.json')", /^.*\.json$/ )
 	.option( "--verbose", "Console additional information" )
-	.option( "-v", "Console the version of tag-release" )
 	.option( "-p, --prerelease", "Create a pre-release" )
 	.option( "-i, --identifier <identifier>", "Identifier used for pre-release" )
 	.option( "--reset", "Reset repo to upstream master/develop branches." )
@@ -38,25 +38,22 @@ commander
 	.option( "--continue", "Continues the rebase process of a tag promotion." );
 
 commander.on( "--help", () => {
-	console.log( "Examples: \n" );
-	console.log( "   $ tag-release" );
-	console.log( "   $ tag-release --config ../../config.json" );
-	console.log( "   $ tag-release -c ./manifest.json" );
-	console.log( "   $ tag-release --release major" );
-	console.log( "   $ tag-release -r minor" );
-	console.log( "   $ tag-release --prerelease" );
-	console.log( "   $ tag-release -p -i rc" );
-	console.log( "   $ tag-release --reset" );
-	console.log( "   $ tag-release --verbose" );
-	console.log( "   $ tag-release -v" );
-	console.log( "   $ tag-release --promote" );
-	console.log( "   $ tag-release --promote v1.1.1-my-tagged-version.0" );
-	console.log( "   $ tag-release --continue" );
-} );
-
-commander.on( "-v", () => {
-	console.log( pkg.version );
-	process.exit( 0 ); // eslint-disable-line
+	console.log( "" );
+	console.log( "  Examples: \n" );
+	console.log( "    $ tag-release" );
+	console.log( "    $ tag-release --config ../../config.json" );
+	console.log( "    $ tag-release -c ./manifest.json" );
+	console.log( "    $ tag-release --release major" );
+	console.log( "    $ tag-release -r minor" );
+	console.log( "    $ tag-release --prerelease" );
+	console.log( "    $ tag-release -p -i rc" );
+	console.log( "    $ tag-release --reset" );
+	console.log( "    $ tag-release --verbose" );
+	console.log( "    $ tag-release -v" );
+	console.log( "    $ tag-release --promote" );
+	console.log( "    $ tag-release --promote v1.1.1-my-tagged-version.0" );
+	console.log( "    $ tag-release --continue" );
+	console.log( "" );
 } );
 
 commander.parse( process.argv );

--- a/src/workflows/default.js
+++ b/src/workflows/default.js
@@ -1,7 +1,7 @@
 import * as run from "./steps";
 
 export default [
-	run.gitFetchUpstreamMaster,
+	run.gitFetchUpstream,
 	run.checkHasDevelopBranch,
 	run.gitCheckoutMaster,
 	run.gitMergeUpstreamMaster,

--- a/src/workflows/pre-release.js
+++ b/src/workflows/pre-release.js
@@ -1,7 +1,7 @@
 import * as run from "./steps";
 
 export default [
-	run.gitFetchUpstreamMaster,
+	run.gitFetchUpstream,
 	run.getCurrentBranchVersion,
 	run.askPrereleaseIdentifier,
 	run.getFeatureBranch,

--- a/src/workflows/promote.js
+++ b/src/workflows/promote.js
@@ -1,7 +1,7 @@
 import * as run from "./steps";
 
 export default [
-	run.gitFetchUpstreamMaster,
+	run.gitFetchUpstream,
 	run.selectPrereleaseToPromote,
 	run.gitCheckoutTag,
 	run.getFeatureBranch,

--- a/src/workflows/reset.js
+++ b/src/workflows/reset.js
@@ -1,7 +1,7 @@
 import * as run from "./steps";
 
 export default [
-	run.gitFetchUpstreamMaster,
+	run.gitFetchUpstream,
 	run.checkHasDevelopBranch,
 	run.checkForUncommittedChanges,
 	run.stashIfUncommittedChangesExist,

--- a/src/workflows/steps.js
+++ b/src/workflows/steps.js
@@ -13,8 +13,8 @@ export function getFeatureBranch( state ) {
 	} );
 }
 
-export function gitFetchUpstreamMaster( state ) {
-	return git.fetchUpstreamMaster();
+export function gitFetchUpstream( state ) {
+	return git.fetchUpstream();
 }
 
 export function gitMergeUpstreamBranch( state ) {


### PR DESCRIPTION
### Short description of the work completed

> Fixed an issue that caused tag-release to only fetch changes in master instead of on the whole upstream remote. There was also an issue with some commands for Windows users when using single quotes instead of double quotes, this has now been addressed. Used to have a `-V, --version` command for tag-release that allow the user to see the current version they were running. This broken at some point in time and it is now working again. Lastly, updated the `README.md` file for new features.

### Steps to test (if not obvious)

1. Do a normal tag-release flow by releasing a change in develop as a full release. This should now properly fetch all changes in upstream instead of just master. You can test this by pushing a change to the develop branch and then attempting to tag-release from develop without having the changes you just pushed.
2. Attempt to do a normal `tag-release` from Windows. Should work as intended.
3. run `tag-release -V` and `tag-release --version`, you should now properly see the current version you are running of `tag-release`

### For Reviewer Use Only

- [x] Code Reviewed
- [x] Tests Passed
- [x] Coverage Reviewed
- [x] Feature worked as expected
- [x] Added or updated flags to `--help` and `README.md`
- [x] Does the feature work in Windows PowerShell?
- [x] Is the version upgrade path clear for this change? (breaking vs minor vs
  patch)
- [x] Follow up work tracked in a card if needed
