### PR TITLE
Bandaided issue with force pushing develop

### DIFF
--- a/specs/workflows/steps.spec.js
+++ b/specs/workflows/steps.spec.js
@@ -2363,4 +2363,30 @@ describe( "shared workflow steps", () => {
 			} );
 		} );
 	} );
+
+	describe( "abortIfDevelopOrMaster", () => {
+		beforeEach( () => {
+			util.advise = jest.fn( () => {} );
+		} );
+
+		it( "should advise when on develop branch", () => {
+			return run.abortIfDevelopOrMaster( { branch: "develop" } ).then( result => {
+				expect( util.advise ).toHaveBeenCalledTimes( 1 );
+				expect( util.advise ).toHaveBeenCalledWith( "abortIfDevelopOrMaster" );
+			} );
+		} );
+
+		it( "should advise when on master branch", () => {
+			return run.abortIfDevelopOrMaster( { branch: "master" } ).then( result => {
+				expect( util.advise ).toHaveBeenCalledTimes( 1 );
+				expect( util.advise ).toHaveBeenCalledWith( "abortIfDevelopOrMaster" );
+			} );
+		} );
+
+		it( "shouldn't advise when on feature branch", () => {
+			return run.abortIfDevelopOrMaster( { branch: "feature-branch" } ).then( result => {
+				expect( util.advise ).toHaveBeenCalledTimes( 0 );
+			} );
+		} );
+	} );
 } );

--- a/src/advise.js
+++ b/src/advise.js
@@ -69,7 +69,8 @@ Please fix all conflict markers with the current conflict before running 'tag-re
 You really shouldn't be seeing this message, so, if you are, ping someone in engineering to see if they can help you figure out what went wrong.`,
 	gitMergeUpstreamBranch: `It appears that when trying to merge with the upstream branch something went wrong.
 
-Either you don't have an upstream with the same name as your local, or we weren't able to 'merge --ff-only' on your local branch with the upstream.`
+Either you don't have an upstream with the same name as your local, or we weren't able to 'merge --ff-only' on your local branch with the upstream.`,
+	abortIfDevelopOrMaster: `It appears you are attempting to run '--qa' from develop or master and your latest commit contains a bump commit.`
 };
 
 const MAXIMUM_WIDTH = 50;

--- a/src/workflows/qa.js
+++ b/src/workflows/qa.js
@@ -31,6 +31,7 @@ export const qaDefault = [
 export const qaUpdate = [
 	run.getPackageScope,
 	run.getFeatureBranch,
+	run.abortIfDevelopOrMaster,
 	run.getCurrentDependencyVersions,
 	run.githubUpstream,
 	run.askVersions,

--- a/src/workflows/steps.js
+++ b/src/workflows/steps.js
@@ -791,3 +791,11 @@ export function getTagsFromRepo( state, repositoryName ) {
 		return tags;
 	} ).catch( err => logger.log( chalk.red( err ) ) );
 }
+
+export function abortIfDevelopOrMaster( state ) {
+	if ( state.branch === "develop" || state.branch === "master" ) {
+		util.advise( "abortIfDevelopOrMaster" );
+	}
+
+	return Promise.resolve();
+}


### PR DESCRIPTION
### Short description of the work completed

> There was an issue that caused --qa to think develop was a re-run of --qa and was attempting to update the package versions and then would force push develop and rewrite the world. 😲 

### Steps to test (if not obvious)

1. Create a commit on develop or master that has our bump commit format: "Bumped [package] to [version]: reason"
2. run tag-release --qa from develop or master with that type of commit message
3. should get an advise that aborts the process.

### For Reviewer Use Only

- [x] Code Reviewed
- [x] Tests Passed
- [x] Coverage Reviewed
- [x] Feature worked as expected
- [x] Added or updated flags to `--help` and `README.md`
- [x] Does the feature work in Windows PowerShell?
- [x] Is the version upgrade path clear for this change? (breaking vs minor vs
  patch)
- [x] Follow up work tracked in a card if needed
