### PR TITLE
Fixed issue when running --qa from develop and master branch

### DIFF
--- a/specs/tag-release.spec.js
+++ b/specs/tag-release.spec.js
@@ -129,10 +129,31 @@ describe( "tag-release", () => {
 			} );
 		} );
 
+		it( "should run the default qa workflow when the CLI flag is passed, on develop and there are packages", () => {
+			tagRelease( { qa: true, packages: [ "my-repo", "my-other-repo" ], branch: "develop" } ).then( () => {
+				expect( sequence ).toHaveBeenCalledTimes( 2 );
+				expect( sequence ).toHaveBeenCalledWith( qaDefault, { qa: true, packages: [ "my-repo", "my-other-repo" ], branch: "develop" } );
+			} );
+		} );
+
+		it( "should run the default qa workflow when the CLI flag is passed, on master and there are packages", () => {
+			tagRelease( { qa: true, packages: [ "my-repo", "my-other-repo" ], branch: "master" } ).then( () => {
+				expect( sequence ).toHaveBeenCalledTimes( 2 );
+				expect( sequence ).toHaveBeenCalledWith( qaDefault, { qa: true, packages: [ "my-repo", "my-other-repo" ], branch: "master" } );
+			} );
+		} );
+
 		it( "should run the update qa workflow when the CLI flag is passed and there are packages", () => {
 			tagRelease( { qa: true, packages: [ "my-repo", "my-other-repo" ] } ).then( () => {
 				expect( sequence ).toHaveBeenCalledTimes( 2 );
 				expect( sequence ).toHaveBeenCalledWith( qaUpdate, { qa: true, packages: [ "my-repo", "my-other-repo" ] } );
+			} );
+		} );
+
+		it( "should run the update qa workflow when the CLI flag is passed, there are packages, and you are on a feature branch", () => {
+			tagRelease( { qa: true, packages: [ "my-repo", "my-other-repo" ], branch: "feature-branch" } ).then( () => {
+				expect( sequence ).toHaveBeenCalledTimes( 2 );
+				expect( sequence ).toHaveBeenCalledWith( qaUpdate, { qa: true, packages: [ "my-repo", "my-other-repo" ], branch: "feature-branch" } );
 			} );
 		} );
 	} );

--- a/specs/workflows/steps.spec.js
+++ b/specs/workflows/steps.spec.js
@@ -2363,30 +2363,4 @@ describe( "shared workflow steps", () => {
 			} );
 		} );
 	} );
-
-	describe( "abortIfDevelopOrMaster", () => {
-		beforeEach( () => {
-			util.advise = jest.fn( () => {} );
-		} );
-
-		it( "should advise when on develop branch", () => {
-			return run.abortIfDevelopOrMaster( { branch: "develop" } ).then( result => {
-				expect( util.advise ).toHaveBeenCalledTimes( 1 );
-				expect( util.advise ).toHaveBeenCalledWith( "abortIfDevelopOrMaster" );
-			} );
-		} );
-
-		it( "should advise when on master branch", () => {
-			return run.abortIfDevelopOrMaster( { branch: "master" } ).then( result => {
-				expect( util.advise ).toHaveBeenCalledTimes( 1 );
-				expect( util.advise ).toHaveBeenCalledWith( "abortIfDevelopOrMaster" );
-			} );
-		} );
-
-		it( "shouldn't advise when on feature branch", () => {
-			return run.abortIfDevelopOrMaster( { branch: "feature-branch" } ).then( result => {
-				expect( util.advise ).toHaveBeenCalledTimes( 0 );
-			} );
-		} );
-	} );
 } );

--- a/src/advise.js
+++ b/src/advise.js
@@ -69,8 +69,7 @@ Please fix all conflict markers with the current conflict before running 'tag-re
 You really shouldn't be seeing this message, so, if you are, ping someone in engineering to see if they can help you figure out what went wrong.`,
 	gitMergeUpstreamBranch: `It appears that when trying to merge with the upstream branch something went wrong.
 
-Either you don't have an upstream with the same name as your local, or we weren't able to 'merge --ff-only' on your local branch with the upstream.`,
-	abortIfDevelopOrMaster: `It appears you are attempting to run '--qa' from develop or master and your latest commit contains a bump commit.`
+Either you don't have an upstream with the same name as your local, or we weren't able to 'merge --ff-only' on your local branch with the upstream.`
 };
 
 const MAXIMUM_WIDTH = 50;

--- a/src/tag-release.js
+++ b/src/tag-release.js
@@ -22,7 +22,8 @@ export default state => {
 
 	if ( state.qa ) {
 		return sequence( qaWorkflow, state ).then( () => {
-			if ( state.packages.length ) {
+			const onFeatureBranch = ( state.branch !== "develop" && state.branch !== "master" );
+			if ( state.packages.length && onFeatureBranch ) {
 				return sequence( qaUpdate, state ).then( () => console.log( "Finished" ) ); // eslint-disable-line no-console
 			}
 

--- a/src/workflows/qa.js
+++ b/src/workflows/qa.js
@@ -2,6 +2,7 @@ import * as run from "./steps";
 
 export default [
 	run.gitFetchUpstream,
+	run.getFeatureBranch,
 	run.getReposFromBumpCommit
 ];
 
@@ -30,8 +31,6 @@ export const qaDefault = [
 
 export const qaUpdate = [
 	run.getPackageScope,
-	run.getFeatureBranch,
-	run.abortIfDevelopOrMaster,
 	run.getCurrentDependencyVersions,
 	run.githubUpstream,
 	run.askVersions,

--- a/src/workflows/steps.js
+++ b/src/workflows/steps.js
@@ -791,11 +791,3 @@ export function getTagsFromRepo( state, repositoryName ) {
 		return tags;
 	} ).catch( err => logger.log( chalk.red( err ) ) );
 }
-
-export function abortIfDevelopOrMaster( state ) {
-	if ( state.branch === "develop" || state.branch === "master" ) {
-		util.advise( "abortIfDevelopOrMaster" );
-	}
-
-	return Promise.resolve();
-}


### PR DESCRIPTION
### Short description of the work completed

> Fixed an issue that was causing --qa to think you updating a --qa created branch when running from develop or master. When running from these branches --qa should always run the default path.

### Steps to test (if not obvious)

1. Run --qa from develop or master and it should run the default path and creating a new branch.
2. Update develop or master branch to have a bump commit as it's first commit ( Bumped [package] to [version]: reason ) The reason for this is because updating a --qa created branch it checks the first commit for that pattern and that is how it determines it is updating a branch instead of creating a new one to be QAed.

### For Reviewer Use Only

- [x] Code Reviewed
- [x] Tests Passed
- [x] Coverage Reviewed
- [x] Feature worked as expected
- [x] Added or updated flags to `--help` and `README.md`
- [x] Does the feature work in Windows PowerShell?
- [x] Is the version upgrade path clear for this change? (breaking vs minor vs
  patch)
- [x] Follow up work tracked in a card if needed
