### PR TITLE
Added logic to strip redundant prefixes from prerelease identifiers.

### DIFF
--- a/specs/workflows/steps.spec.js
+++ b/specs/workflows/steps.spec.js
@@ -171,20 +171,20 @@ describe( "shared workflow steps", () => {
 		} );
 	} );
 
-	describe( "askPrereleaseIdentifier", () => {
+	describe( "setPrereleaseIdentifier", () => {
 		beforeEach( () => {
 			util.prompt = jest.fn( () => Promise.resolve( { prereleaseIdentifier: "pre" } ) );
 		} );
 
 		it( "should not prompt if an identifier was provided at the command line", () => {
 			state = { identifier: "test" };
-			return run.askPrereleaseIdentifier( state ).then( () => {
+			return run.setPrereleaseIdentifier( state ).then( () => {
 				expect( util.prompt ).not.toHaveBeenCalled();
 			} );
 		} );
 
 		it( "should prompt the user for a prerelease identifier", () => {
-			return run.askPrereleaseIdentifier( state ).then( () => {
+			return run.setPrereleaseIdentifier( state ).then( () => {
 				expect( util.prompt ).toHaveBeenCalledTimes( 1 );
 				expect( util.prompt ).toHaveBeenCalledWith( [ {
 					type: "input",
@@ -195,9 +195,18 @@ describe( "shared workflow steps", () => {
 		} );
 
 		it( "should persist the given identifier to the workflow state", () => {
-			return run.askPrereleaseIdentifier( state ).then( () => {
+			return run.setPrereleaseIdentifier( state ).then( () => {
 				expect( state ).toHaveProperty( "identifier" );
 				expect( state.identifier ).toEqual( "pre" );
+			} );
+		} );
+
+		[ "defect", "feature", "rework" ].forEach( redundantIdentifierPrefix => {
+			it( `should strip "${ redundantIdentifierPrefix }-" from the beginning of the identifier when it is present`, () => {
+				state = { identifier: `${ redundantIdentifierPrefix }-test-prerelease-identifier` };
+				return run.setPrereleaseIdentifier( state ).then( () => {
+					expect( state.identifier ).toEqual( "test-prerelease-identifier" );
+				} );
 			} );
 		} );
 	} );

--- a/src/workflows/pre-release.js
+++ b/src/workflows/pre-release.js
@@ -3,7 +3,7 @@ import * as run from "./steps";
 export default [
 	run.gitFetchUpstream,
 	run.getCurrentBranchVersion,
-	run.askPrereleaseIdentifier,
+	run.setPrereleaseIdentifier,
 	run.getFeatureBranch,
 	run.gitMergeUpstreamBranch,
 	run.gitShortLog,

--- a/src/workflows/steps.js
+++ b/src/workflows/steps.js
@@ -48,10 +48,15 @@ export function checkHasDevelopBranch( state ) {
 	} );
 }
 
-export function askPrereleaseIdentifier( state ) {
+export function setPrereleaseIdentifier( state ) {
 	const { identifier } = state;
 
+	const cleanIdentifier = targetIdentifier => {
+		return targetIdentifier.replace( /^(defect|feature|rework)-/, "" );
+	};
+
 	if ( identifier && identifier.length ) {
+		state.identifier = cleanIdentifier( state.identifier );
 		return Promise.resolve();
 	}
 
@@ -60,7 +65,7 @@ export function askPrereleaseIdentifier( state ) {
 		name: "prereleaseIdentifier",
 		message: "Pre-release Identifier:"
 	} ] ).then( response => {
-		state.identifier = response.prereleaseIdentifier;
+		state.identifier = cleanIdentifier( response.prereleaseIdentifier );
 		return Promise.resolve();
 	} );
 }


### PR DESCRIPTION
### Short description of the work completed

> This PR adds logic to the (formerly) `askPrereleaseIdentifier` function (renamed to `setPrereleaseIdentifier`) to strip off redundant prefixes ("defect", "feature" and "rework"). It should satisfy the requirements for #70.

### Steps to test (if not obvious)

1. Run `tag-release` in either of the following two manners:
     1. run `tag-release --pi feature-some-fun-new-thingy`, OR
     2. run `tag-release -p` (without providing the prerelease identifier as a CLI argument)...
          * when prompted to provide an identifier for the prerelease, enter something like `defect-some-bad-thing`

Expected result: the resulting tag for the prerelease should NOT include either `feature-` or `defect-` as a prefix. That will eventually be prepended when the upstream branch is created, and if it is there, it would make the generated upstream branch name contain the redundant prefix.

### For Reviewer Use Only

- [x] Code Reviewed
- [x] Tests Passed
- [x] Coverage Reviewed
- [x] Feature worked as expected
- [x] Added or updated flags to `--help` and `README.md`
- [x] Does the feature work in Windows PowerShell?
- [x] Is the version upgrade path clear for this change? (breaking vs minor vs
  patch)
- [x] Follow up work tracked in a card if needed
