### PR TITLE
Removed --qa step to create an upstream branch before pushing into it

### DIFF
--- a/specs/git.spec.js
+++ b/specs/git.spec.js
@@ -190,10 +190,6 @@ describe( "git", () => {
 				args: "test-branch",
 				expectedRunCommandArgs: { args: "branch test-branch upstream/test-branch", logMessage: `Creating local branch "test-branch"` }
 			},
-			createUpstreamBranch: {
-				args: "feature-branch",
-				expectedRunCommandArgs: { args: "push upstream feature-branch", logMessage: `Creating upstream branch "feature-branch"` }
-			},
 			resetBranch: {
 				args: "test-branch",
 				expectedRunCommandArgs: { args: "reset --hard upstream/test-branch", logMessage: `Hard reset on branch: "test-branch"` }

--- a/specs/workflows/steps.spec.js
+++ b/specs/workflows/steps.spec.js
@@ -1887,20 +1887,6 @@ describe( "shared workflow steps", () => {
 		} );
 	} );
 
-	describe( "gitCreateUpstreamBranch", () => {
-		beforeEach( () => {
-			git.createUpstreamBranch = jest.fn( () => Promise.resolve() );
-		} );
-
-		it( "should call `git.createUpstreamBranch` with the appropriate argument", () => {
-			state.branch = "feature-this-is-a-reason";
-			return run.gitCreateUpstreamBranch( state ).then( () => {
-				expect( git.createUpstreamBranch ).toHaveBeenCalledTimes( 1 );
-				expect( git.createUpstreamBranch ).toHaveBeenCalledWith( "feature-this-is-a-reason" );
-			} );
-		} );
-	} );
-
 	describe( "verifyPackagesToPromote", () => {
 		const originalProcessExit = process.exit;
 

--- a/src/git.js
+++ b/src/git.js
@@ -204,11 +204,6 @@ const git = {
 		return git.runCommand( { args, logMessage: `Creating local branch "${ branch }"` } );
 	},
 
-	createUpstreamBranch( branch ) {
-		const args = `push upstream ${ branch }`;
-		return git.runCommand( { args, logMessage: `Creating upstream branch "${ branch }"` } );
-	},
-
 	resetBranch( branch ) {
 		const args = `reset --hard upstream/${ branch }`;
 		return git.runCommand( { args, logMessage: `Hard reset on branch: "${ branch }"` } );

--- a/src/workflows/qa.js
+++ b/src/workflows/qa.js
@@ -22,7 +22,6 @@ export const qaDefault = [
 	run.getFeatureBranch,
 	run.updateDependencies,
 	run.gitDiff,
-	run.gitCreateUpstreamBranch,
 	run.gitAdd,
 	run.gitCommitBumpMessage,
 	run.gitPushUpstreamFeatureBranch

--- a/src/workflows/steps.js
+++ b/src/workflows/steps.js
@@ -640,10 +640,6 @@ export function gitCommitBumpMessage( state ) {
 	return git.commit( state.bumpComment );
 }
 
-export function gitCreateUpstreamBranch( state ) {
-	return git.createUpstreamBranch( state.branch );
-}
-
 export function verifyPackagesToPromote( state ) {
 	const { packages } = state;
 	if ( packages && packages.length === 0 ) {


### PR DESCRIPTION
### Short description of the work completed

> Removed step that caused drone to do an extra build when using the --qa feature. This was caused because we would create a branch on the upstream which would trigger a drone build and then we would push into it which would cause it to build again.

### Steps to test (if not obvious)

1. Run `tag-release --qa`
2. Follow steps
3. Should no longer create branch before pushing into it. Should create it as it is pushed into the upstream.

### For Reviewer Use Only

- [x] Code Reviewed
- [x] Tests Passed
- [x] Coverage Reviewed
- [x] Feature worked as expected
- [x] Added or updated flags to `--help` and `README.md`
- [x] Does the feature work in Windows PowerShell?
- [x] Is the version upgrade path clear for this change? (breaking vs minor vs
  patch)
- [x] Follow up work tracked in a card if needed
