### PR TITLE
Refactored common sequential steps into shared workflow groups for reuse

### DIFF
--- a/specs/workflows/continue.spec.js
+++ b/specs/workflows/continue.spec.js
@@ -1,0 +1,13 @@
+import continueWorkflow from "../../src/workflows/continue";
+import * as run from "../../src/workflows/steps";
+
+describe( "continue workflow", () => {
+	it( "should have all of the required steps", () => {
+		expect( continueWorkflow ).toEqual( [
+			run.verifyConflictResolution,
+			run.gitStageFiles,
+			run.gitRebaseContinue,
+			run.getFeatureBranch
+		] );
+	} );
+} );

--- a/specs/workflows/default.spec.js
+++ b/specs/workflows/default.spec.js
@@ -1,0 +1,33 @@
+import defaultWorkflow from "../../src/workflows/default";
+import * as run from "../../src/workflows/steps";
+
+describe( "default workflow", () => {
+	it( "should have all of the required steps", () => {
+		expect( defaultWorkflow ).toEqual( [
+			run.gitFetchUpstream,
+			run.checkHasDevelopBranch,
+			run.gitCheckoutMaster,
+			run.gitMergeUpstreamMaster,
+			run.getCurrentBranchVersion,
+			run.gitMergeUpstreamDevelop,
+			run.gitShortLog,
+			run.previewLog,
+			run.askSemverJump,
+			run.updateLog,
+			run.updateVersion,
+			run.updateChangelog,
+			run.gitDiff,
+			run.gitAdd,
+			run.gitCommit,
+			run.gitTag,
+			run.gitPushUpstreamMaster,
+			run.npmPublish,
+			run.gitCheckoutDevelop,
+			run.gitMergeMaster,
+			run.gitPushUpstreamDevelop,
+			run.gitPushOriginMaster,
+			run.githubUpstream,
+			run.githubRelease
+		] );
+	} );
+} );

--- a/specs/workflows/pr.spec.js
+++ b/specs/workflows/pr.spec.js
@@ -1,0 +1,49 @@
+import { default as prWorkflow, keepTheBallRolling } from "../../src/workflows/pr";
+import * as run from "../../src/workflows/steps";
+
+describe( "pr workflows", () => {
+	describe( "default", () => {
+		it( "should have all of the required steps", () => {
+			expect( prWorkflow ).toEqual( [
+				run.gitFetchUpstream,
+				run.getPackageScope,
+				run.getFeatureBranch,
+				run.gitRebaseUpstreamBranch,
+				run.saveState,
+				run.gitRebaseUpstreamDevelop,
+				run.getReposFromBumpCommit,
+				run.verifyPackagesToPromote,
+				run.getCurrentDependencyVersions,
+				run.githubUpstream,
+				run.askVersions,
+				run.updateDependencies,
+				run.gitDiff,
+				run.gitAdd,
+				run.gitAmendCommitBumpMessage,
+				run.gitForcePushUpstreamFeatureBranch,
+				run.githubUpstream,
+				run.createGithubPullRequestAganistDevelop,
+				run.cleanUpTmpFiles
+			] );
+		} );
+	} );
+
+	describe( "keepTheBallRolling", () => {
+		expect( keepTheBallRolling ).toEqual( [
+			run.getPackageScope,
+			run.getReposFromBumpCommit,
+			run.verifyPackagesToPromote,
+			run.getCurrentDependencyVersions,
+			run.githubUpstream,
+			run.askVersions,
+			run.updateDependencies,
+			run.gitDiff,
+			run.gitAdd,
+			run.gitAmendCommitBumpMessage,
+			run.gitForcePushUpstreamFeatureBranch,
+			run.githubUpstream,
+			run.createGithubPullRequestAganistDevelop,
+			run.cleanUpTmpFiles
+		] );
+	} );
+} );

--- a/specs/workflows/pre-release.spec.js
+++ b/specs/workflows/pre-release.spec.js
@@ -1,0 +1,26 @@
+import preReleaseWorkflow from "../../src/workflows/pre-release";
+import * as run from "../../src/workflows/steps";
+
+describe( "pre-release workflow", () => {
+	it( "should have all of the required steps", () => {
+		expect( preReleaseWorkflow ).toEqual( [
+			run.gitFetchUpstream,
+			run.getCurrentBranchVersion,
+			run.setPrereleaseIdentifier,
+			run.getFeatureBranch,
+			run.gitMergeUpstreamBranch,
+			run.gitShortLog,
+			run.previewLog,
+			run.askSemverJump,
+			run.updateVersion,
+			run.gitDiff,
+			run.gitStageConfigFile,
+			run.gitCommit,
+			run.gitTag,
+			run.gitPushUpstreamFeatureBranch,
+			run.npmPublish,
+			run.githubUpstream,
+			run.githubRelease
+		] );
+	} );
+} );

--- a/specs/workflows/promote.spec.js
+++ b/specs/workflows/promote.spec.js
@@ -1,0 +1,77 @@
+import { default as promoteWorkflow, keepTheBallRolling } from "../../src/workflows/promote";
+import * as run from "../../src/workflows/steps";
+
+describe( "promote workflows", () => {
+	describe( "default", () => {
+		it( "should have all of the required steps", () => {
+			expect( promoteWorkflow ).toEqual( [
+				run.gitFetchUpstream,
+				run.selectPrereleaseToPromote,
+				run.gitCheckoutTag,
+				run.getFeatureBranch,
+				run.gitGenerateRebaseCommitLog,
+				run.gitRemovePreReleaseCommits,
+				run.gitRebaseUpstreamMaster,
+				run.gitCheckoutMaster,
+				run.gitMergeUpstreamMaster,
+				run.gitMergePromotionBranch,
+				run.gitMergeUpstreamBranch,
+				run.checkHasDevelopBranch,
+				run.getCurrentBranchVersion,
+				run.gitMergeUpstreamDevelop,
+				run.gitShortLog,
+				run.previewLog,
+				run.askSemverJump,
+				run.updateLog,
+				run.updateVersion,
+				run.updateChangelog,
+				run.gitDiff,
+				run.gitAdd,
+				run.gitCommit,
+				run.gitTag,
+				run.gitPushUpstreamMaster,
+				run.npmPublish,
+				run.gitCheckoutDevelop,
+				run.gitMergeMaster,
+				run.gitPushUpstreamDevelop,
+				run.gitPushOriginMaster,
+				run.githubUpstream,
+				run.githubRelease,
+				run.cleanUpTmpFiles
+			] );
+		} );
+	} );
+
+	describe( "keepTheBallRolling", () => {
+		it( "should have all of the required steps", () => {
+			expect( keepTheBallRolling ).toEqual( [
+				run.setPromote,
+				run.checkHasDevelopBranch,
+				run.gitCheckoutMaster,
+				run.gitMergeUpstreamMaster,
+				run.gitMergePromotionBranch,
+				run.getCurrentBranchVersion,
+				run.gitMergeUpstreamDevelop,
+				run.gitShortLog,
+				run.previewLog,
+				run.askSemverJump,
+				run.updateLog,
+				run.updateVersion,
+				run.updateChangelog,
+				run.gitDiff,
+				run.gitAdd,
+				run.gitCommit,
+				run.gitTag,
+				run.gitPushUpstreamMaster,
+				run.npmPublish,
+				run.gitCheckoutDevelop,
+				run.gitMergeMaster,
+				run.gitPushUpstreamDevelop,
+				run.gitPushOriginMaster,
+				run.githubUpstream,
+				run.githubRelease,
+				run.cleanUpTmpFiles
+			] );
+		} );
+	} );
+} );

--- a/specs/workflows/qa.spec.js
+++ b/specs/workflows/qa.spec.js
@@ -1,0 +1,54 @@
+import { default as qaWorkflow, qaDefault, qaUpdate } from "../../src/workflows/qa";
+import * as run from "../../src/workflows/steps";
+
+describe( "qa workflows", () => {
+	describe( "qaWorkflow", () => {
+		it( "should have all of the required steps", () => {
+			expect( qaWorkflow ).toEqual( [
+				run.gitFetchUpstream,
+				run.getFeatureBranch,
+				run.getReposFromBumpCommit
+			] );
+		} );
+	} );
+	describe( "qaDefault", () => {
+		it( "should have all of the required steps", () => {
+			expect( qaDefault ).toEqual( [
+				run.checkHasDevelopBranch,
+				run.gitCheckoutDevelop,
+				run.gitRebaseUpstreamDevelop,
+				run.getPackageScope,
+				run.askReposToUpdate,
+				run.verifyPackagesToPromote,
+				run.getCurrentDependencyVersions,
+				run.askChangeReason,
+				run.githubUpstream,
+				run.askVersions,
+				run.askChangeType,
+				run.promptBranchName,
+				run.gitCheckoutAndCreateBranch,
+				run.getFeatureBranch,
+				run.updateDependencies,
+				run.gitDiff,
+				run.gitAdd,
+				run.gitCommitBumpMessage,
+				run.gitPushUpstreamFeatureBranch
+			] );
+		} );
+	} );
+	describe( "qaUpdate", () => {
+		it( "should have all of the required steps", () => {
+			expect( qaUpdate ).toEqual( [
+				run.getPackageScope,
+				run.getCurrentDependencyVersions,
+				run.githubUpstream,
+				run.askVersions,
+				run.updateDependencies,
+				run.gitDiff,
+				run.gitAdd,
+				run.gitAmendCommitBumpMessage,
+				run.gitForcePushUpstreamFeatureBranch
+			] );
+		} );
+	} );
+} );

--- a/specs/workflows/reset.spec.js
+++ b/specs/workflows/reset.spec.js
@@ -1,0 +1,21 @@
+import resetWorkflow from "../../src/workflows/reset";
+import * as run from "../../src/workflows/steps";
+
+describe( "reset workflow", () => {
+	it( "should have all of the required steps", () => {
+		expect( resetWorkflow ).toEqual( [
+			run.gitFetchUpstream,
+			run.checkHasDevelopBranch,
+			run.checkForUncommittedChanges,
+			run.stashIfUncommittedChangesExist,
+			run.verifyMasterBranch,
+			run.gitCheckoutMaster,
+			run.gitResetMaster,
+			run.gitRemovePromotionBranches,
+			run.verifyDevelopBranch,
+			run.gitCheckoutDevelop,
+			run.gitResetDevelop,
+			run.cleanUpTmpFiles
+		] );
+	} );
+} );

--- a/specs/workflows/shared.spec.js
+++ b/specs/workflows/shared.spec.js
@@ -1,0 +1,51 @@
+import { rebaseUpdateLogCommitTagRelease, createPullRequest } from "../../src/workflows/shared";
+import * as run from "../../src/workflows/steps";
+
+describe( "shared workflows", () => {
+	describe( "rebaseUpdateLogCommitTagRelease", () => {
+		it( "should have all of the required steps", () => {
+			expect( rebaseUpdateLogCommitTagRelease ).toEqual( [
+				run.getCurrentBranchVersion,
+				run.gitMergeUpstreamDevelop,
+				run.gitShortLog,
+				run.previewLog,
+				run.askSemverJump,
+				run.updateLog,
+				run.updateVersion,
+				run.updateChangelog,
+				run.gitDiff,
+				run.gitAdd,
+				run.gitCommit,
+				run.gitTag,
+				run.gitPushUpstreamMaster,
+				run.npmPublish,
+				run.gitCheckoutDevelop,
+				run.gitMergeMaster,
+				run.gitPushUpstreamDevelop,
+				run.gitPushOriginMaster,
+				run.githubUpstream,
+				run.githubRelease
+			] );
+		} );
+	} );
+
+	describe( "createPullRequest", () => {
+		it( "should have all of the required steps", () => {
+			expect( createPullRequest ).toEqual( [
+				run.getReposFromBumpCommit,
+				run.verifyPackagesToPromote,
+				run.getCurrentDependencyVersions,
+				run.githubUpstream,
+				run.askVersions,
+				run.updateDependencies,
+				run.gitDiff,
+				run.gitAdd,
+				run.gitAmendCommitBumpMessage,
+				run.gitForcePushUpstreamFeatureBranch,
+				run.githubUpstream,
+				run.createGithubPullRequestAganistDevelop,
+				run.cleanUpTmpFiles
+			] );
+		} );
+	} );
+} );

--- a/src/workflows/default.js
+++ b/src/workflows/default.js
@@ -1,28 +1,10 @@
 import * as run from "./steps";
+import { rebaseUpdateLogCommitTagRelease } from "./shared";
 
 export default [
 	run.gitFetchUpstream,
 	run.checkHasDevelopBranch,
 	run.gitCheckoutMaster,
 	run.gitMergeUpstreamMaster,
-	run.getCurrentBranchVersion,
-	run.gitMergeUpstreamDevelop,
-	run.gitShortLog,
-	run.previewLog,
-	run.askSemverJump,
-	run.updateLog,
-	run.updateVersion,
-	run.updateChangelog,
-	run.gitDiff,
-	run.gitAdd,
-	run.gitCommit,
-	run.gitTag,
-	run.gitPushUpstreamMaster,
-	run.npmPublish,
-	run.gitCheckoutDevelop,
-	run.gitMergeMaster,
-	run.gitPushUpstreamDevelop,
-	run.gitPushOriginMaster,
-	run.githubUpstream,
-	run.githubRelease
+	...rebaseUpdateLogCommitTagRelease
 ];

--- a/src/workflows/pr.js
+++ b/src/workflows/pr.js
@@ -1,4 +1,5 @@
 import * as run from "./steps";
+import { createPullRequest } from "./shared";
 
 export default [
 	run.gitFetchUpstream,
@@ -7,34 +8,10 @@ export default [
 	run.gitRebaseUpstreamBranch,
 	run.saveState,
 	run.gitRebaseUpstreamDevelop,
-	run.getReposFromBumpCommit,
-	run.verifyPackagesToPromote,
-	run.getCurrentDependencyVersions,
-	run.githubUpstream,
-	run.askVersions,
-	run.updateDependencies,
-	run.gitDiff,
-	run.gitAdd,
-	run.gitAmendCommitBumpMessage,
-	run.gitForcePushUpstreamFeatureBranch,
-	run.githubUpstream,
-	run.createGithubPullRequestAganistDevelop,
-	run.cleanUpTmpFiles
+	...createPullRequest
 ];
 
 export const keepTheBallRolling = [
 	run.getPackageScope,
-	run.getReposFromBumpCommit,
-	run.verifyPackagesToPromote,
-	run.getCurrentDependencyVersions,
-	run.githubUpstream,
-	run.askVersions,
-	run.updateDependencies,
-	run.gitDiff,
-	run.gitAdd,
-	run.gitAmendCommitBumpMessage,
-	run.gitForcePushUpstreamFeatureBranch,
-	run.githubUpstream,
-	run.createGithubPullRequestAganistDevelop,
-	run.cleanUpTmpFiles
+	...createPullRequest
 ];

--- a/src/workflows/promote.js
+++ b/src/workflows/promote.js
@@ -1,4 +1,5 @@
 import * as run from "./steps";
+import { rebaseUpdateLogCommitTagRelease } from "./shared";
 
 export default [
 	run.gitFetchUpstream,
@@ -13,26 +14,7 @@ export default [
 	run.gitMergePromotionBranch,
 	run.gitMergeUpstreamBranch,
 	run.checkHasDevelopBranch,
-	run.getCurrentBranchVersion,
-	run.gitMergeUpstreamDevelop,
-	run.gitShortLog,
-	run.previewLog,
-	run.askSemverJump,
-	run.updateLog,
-	run.updateVersion,
-	run.updateChangelog,
-	run.gitDiff,
-	run.gitAdd,
-	run.gitCommit,
-	run.gitTag,
-	run.gitPushUpstreamMaster,
-	run.npmPublish,
-	run.gitCheckoutDevelop,
-	run.gitMergeMaster,
-	run.gitPushUpstreamDevelop,
-	run.gitPushOriginMaster,
-	run.githubUpstream,
-	run.githubRelease,
+	...rebaseUpdateLogCommitTagRelease,
 	run.cleanUpTmpFiles
 ];
 
@@ -42,25 +24,6 @@ export const keepTheBallRolling = [
 	run.gitCheckoutMaster,
 	run.gitMergeUpstreamMaster,
 	run.gitMergePromotionBranch,
-	run.getCurrentBranchVersion,
-	run.gitMergeUpstreamDevelop,
-	run.gitShortLog,
-	run.previewLog,
-	run.askSemverJump,
-	run.updateLog,
-	run.updateVersion,
-	run.updateChangelog,
-	run.gitDiff,
-	run.gitAdd,
-	run.gitCommit,
-	run.gitTag,
-	run.gitPushUpstreamMaster,
-	run.npmPublish,
-	run.gitCheckoutDevelop,
-	run.gitMergeMaster,
-	run.gitPushUpstreamDevelop,
-	run.gitPushOriginMaster,
-	run.githubUpstream,
-	run.githubRelease,
+	...rebaseUpdateLogCommitTagRelease,
 	run.cleanUpTmpFiles
 ];

--- a/src/workflows/shared.js
+++ b/src/workflows/shared.js
@@ -1,0 +1,41 @@
+import * as run from "./steps";
+
+export default {
+	rebaseUpdateLogCommitTagRelease: [
+		run.getCurrentBranchVersion,
+		run.gitMergeUpstreamDevelop,
+		run.gitShortLog,
+		run.previewLog,
+		run.askSemverJump,
+		run.updateLog,
+		run.updateVersion,
+		run.updateChangelog,
+		run.gitDiff,
+		run.gitAdd,
+		run.gitCommit,
+		run.gitTag,
+		run.gitPushUpstreamMaster,
+		run.npmPublish,
+		run.gitCheckoutDevelop,
+		run.gitMergeMaster,
+		run.gitPushUpstreamDevelop,
+		run.gitPushOriginMaster,
+		run.githubUpstream,
+		run.githubRelease
+	],
+	createPullRequest: [
+		run.getReposFromBumpCommit,
+		run.verifyPackagesToPromote,
+		run.getCurrentDependencyVersions,
+		run.githubUpstream,
+		run.askVersions,
+		run.updateDependencies,
+		run.gitDiff,
+		run.gitAdd,
+		run.gitAmendCommitBumpMessage,
+		run.gitForcePushUpstreamFeatureBranch,
+		run.githubUpstream,
+		run.createGithubPullRequestAganistDevelop,
+		run.cleanUpTmpFiles
+	]
+};

--- a/src/workflows/shared.js
+++ b/src/workflows/shared.js
@@ -1,41 +1,40 @@
 import * as run from "./steps";
 
-export default {
-	rebaseUpdateLogCommitTagRelease: [
-		run.getCurrentBranchVersion,
-		run.gitMergeUpstreamDevelop,
-		run.gitShortLog,
-		run.previewLog,
-		run.askSemverJump,
-		run.updateLog,
-		run.updateVersion,
-		run.updateChangelog,
-		run.gitDiff,
-		run.gitAdd,
-		run.gitCommit,
-		run.gitTag,
-		run.gitPushUpstreamMaster,
-		run.npmPublish,
-		run.gitCheckoutDevelop,
-		run.gitMergeMaster,
-		run.gitPushUpstreamDevelop,
-		run.gitPushOriginMaster,
-		run.githubUpstream,
-		run.githubRelease
-	],
-	createPullRequest: [
-		run.getReposFromBumpCommit,
-		run.verifyPackagesToPromote,
-		run.getCurrentDependencyVersions,
-		run.githubUpstream,
-		run.askVersions,
-		run.updateDependencies,
-		run.gitDiff,
-		run.gitAdd,
-		run.gitAmendCommitBumpMessage,
-		run.gitForcePushUpstreamFeatureBranch,
-		run.githubUpstream,
-		run.createGithubPullRequestAganistDevelop,
-		run.cleanUpTmpFiles
-	]
-};
+export const rebaseUpdateLogCommitTagRelease = [
+	run.getCurrentBranchVersion,
+	run.gitMergeUpstreamDevelop,
+	run.gitShortLog,
+	run.previewLog,
+	run.askSemverJump,
+	run.updateLog,
+	run.updateVersion,
+	run.updateChangelog,
+	run.gitDiff,
+	run.gitAdd,
+	run.gitCommit,
+	run.gitTag,
+	run.gitPushUpstreamMaster,
+	run.npmPublish,
+	run.gitCheckoutDevelop,
+	run.gitMergeMaster,
+	run.gitPushUpstreamDevelop,
+	run.gitPushOriginMaster,
+	run.githubUpstream,
+	run.githubRelease
+];
+
+export const createPullRequest = [
+	run.getReposFromBumpCommit,
+	run.verifyPackagesToPromote,
+	run.getCurrentDependencyVersions,
+	run.githubUpstream,
+	run.askVersions,
+	run.updateDependencies,
+	run.gitDiff,
+	run.gitAdd,
+	run.gitAmendCommitBumpMessage,
+	run.gitForcePushUpstreamFeatureBranch,
+	run.githubUpstream,
+	run.createGithubPullRequestAganistDevelop,
+	run.cleanUpTmpFiles
+];


### PR DESCRIPTION
### Short description of the work completed

> Some minor refactoring that extracts groups of common sequences of workflow steps into shared collections that can be reused across multiple workflows.

### Steps to test (if not obvious)

Just a simple regression should be sufficient. No functionality should be changed at all, this is just a refactoring.

### For Reviewer Use Only

- [x] Code Reviewed
- [x] Tests Passed
- [x] Coverage Reviewed
- [x] Feature worked as expected
- [x] Added or updated flags to `--help` and `README.md`
- [x] Does the feature work in Windows PowerShell?
- [x] Is the version upgrade path clear for this change? (breaking vs minor vs
  patch)
- [x] Follow up work tracked in a card if needed
