### PR TITLE
Fixed npm publish from publishing pre-releases as latest release

### DIFF
--- a/specs/workflows/steps.spec.js
+++ b/specs/workflows/steps.spec.js
@@ -909,6 +909,24 @@ describe( "shared workflow steps", () => {
 			} );
 		} );
 
+		it( "should publish with identifier for pre-releases", () => {
+			state = { configPath: "./package.json", prerelease: true, identifier: "my-identifier" };
+			util.prompt = jest.fn( () => Promise.resolve( { publish: true } ) );
+			return run.npmPublish( state ).then( () => {
+				expect( util.log.begin ).toHaveBeenCalledWith( "npm publish --tag my-identifier" );
+				expect( util.exec ).toHaveBeenCalledWith( "npm publish --tag my-identifier" );
+			} );
+		} );
+
+		it( "should publish for releases", () => {
+			state = { configPath: "./package.json", prerelease: false };
+			util.prompt = jest.fn( () => Promise.resolve( { publish: true } ) );
+			return run.npmPublish( state ).then( () => {
+				expect( util.log.begin ).toHaveBeenCalledWith( "npm publish" );
+				expect( util.exec ).toHaveBeenCalledWith( "npm publish" );
+			} );
+		} );
+
 		it( "should not prompt if the package is private", () => {
 			util.isPackagePrivate = jest.fn( () => true );
 			util.getPackageRegistry = jest.fn( () => Promise.resolve() );

--- a/src/workflows/steps.js
+++ b/src/workflows/steps.js
@@ -295,12 +295,13 @@ export function gitPushUpstreamMaster() {
 }
 
 export function npmPublish( state ) {
-	const { configPath } = state;
+	const { configPath, identifier, prerelease } = state;
 	if ( configPath !== "./package.json" ) {
 		return null;
 	}
 
-	const command = `npm publish`;
+	let command = "npm publish";
+	command = prerelease && identifier ? `${ command } --tag ${ identifier }` : command;
 
 	if ( !util.isPackagePrivate( configPath ) ) {
 		return util.getPackageRegistry( configPath ).then( registry => {


### PR DESCRIPTION
### Short description of the work completed

> npm publish was publishing every releases as if it was the latest. Pre-releases shouldn't be considered the latest, instead they should be beta type releases that people can opt into not installed by default when using `npm install -g tag-release`. This change fixes our publish step to only run `npm publish` for official releases and `npm publish --tag { identifer }` for any pre-release releases.

### Steps to test (if not obvious)

1. Create a new branch
2. Make a change
3. Run `tag-release --prelease`
4. After following the pre-release steps you should see `npm publish --tag { identifer }` as one of the commands ran.
5. Go into master or develop branch
6. Make a change
7. Run `tag-release` 
8 After following the steps you should see `npm publish` as it was before since tag-release is creating an official release. Same goes for `tag-release --promote`

### For Reviewer Use Only

- [x] Code Reviewed
- [x] Tests Passed
- [x] Coverage Reviewed
- [x] Feature worked as expected
- [x] Added or updated flags to `--help` and `README.md`
- [x] Does the feature work in Windows PowerShell?
- [x] Is the version upgrade path clear for this change? (breaking vs minor vs
  patch)
- [x] Follow up work tracked in a card if needed
