### PR TITLE
Refactored help output, and added link to LK tag-release workflow docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "cover": "npm test",
     "cover:watch": "npm run test:watch",
     "cover:open": "open coverage/lcov-report/index.html",
-    "pre-commit": "echo 'Running pre-commit hooks...' && exit 0"
+    "pre-commit": "echo 'Running pre-commit hooks...' && exit 0",
+    "pretest": "npm run lint"
   },
   "pre-commit": [
     "pre-commit",

--- a/specs/help.spec.js
+++ b/specs/help.spec.js
@@ -1,0 +1,84 @@
+jest.mock( "chalk", () => ( {
+	yellow: {
+		underline: {
+			bold: jest.fn( arg => arg )
+		}
+	},
+	green: {
+		underline: {
+			bold: jest.fn( arg => arg )
+		}
+	}
+} ) );
+
+import chalk from "chalk"; // eslint-disable-line no-unused-vars
+
+/* eslint-disable global-require */
+describe( "help", () => {
+	let util, help;
+
+	beforeEach( () => {
+		jest.doMock( "../src/utils", () => ( {
+			hasLkScope: jest.fn( () => true ),
+			renderHelpContent: jest.fn( arg => arg )
+		} ) );
+
+		util = require( "../src/utils" );
+		help = require( "../src/help" ).default;
+	} );
+
+	it( "should return custom help output", () => {
+		help();
+		expect( util.renderHelpContent ).toHaveBeenCalledTimes( 1 );
+		expect( util.renderHelpContent.mock.calls[ 0 ][ 0 ] ).toEqual( expect.stringContaining( `
+  Examples:
+
+    $ tag-release
+    $ tag-release --config ../../config.json
+    $ tag-release -c ./manifest.json
+    $ tag-release --release major
+    $ tag-release -r minor
+    $ tag-release --prerelease
+    $ tag-release -p -i rc
+    $ tag-release --reset
+    $ tag-release --verbose
+    $ tag-release -v
+    $ tag-release --promote
+    $ tag-release --promote v1.1.1-my-tagged-version.0
+    $ tag-release --continue
+    $ tag-release --qa
+    $ tag-release --qa myorg
+    $ tag-release --pr
+    $ tag-release --pr myorg
+
+  Link to README: https://github.com/LeanKit-Labs/tag-release/blob/master/README.md
+  LeanKit tag-release workflow: https://leankit-wiki.atlassian.net/wiki/spaces/PD/pages/96347952/tag-release+workflow
+` 		) );
+	} );
+
+	describe( "when the user has an @lk registry scope", () => {
+		it( "the help output should include a link to the LeanKit tag-release workflow doc", () => {
+			help();
+			expect( util.renderHelpContent.mock.calls[ 0 ][ 0 ] ).toEqual( expect.stringContaining( "LeanKit tag-release workflow: https://leankit-wiki.atlassian.net/wiki/spaces/PD/pages/96347952/tag-release+workflow" ) );
+		} );
+	} );
+
+	describe( "when the user does not have an @lk registry scope", () => {
+		beforeEach( () => {
+			jest.resetModules();
+			jest.doMock( "../src/utils", () => ( {
+				hasLkScope: jest.fn( () => false ),
+				renderHelpContent: jest.fn( arg => arg )
+			} ) );
+
+			util = require( "../src/utils" );
+			help = require( "../src/help" ).default;
+		} );
+
+		it( "the help output should NOT include a link to the LeanKit tag-release workflow doc", () => {
+			help();
+			expect( util.renderHelpContent.mock.calls[ 0 ][ 0 ] ).not.toMatch( /LeanKit tag-release workflow: https:\/\/leankit-wiki.atlassian.net\/wiki\/spaces\/PD\/pages\/96347952\/tag-release+workflow/ );
+		} );
+	} );
+} );
+/* eslint-enable global-require */

--- a/specs/utils.spec.js
+++ b/specs/utils.spec.js
@@ -1,6 +1,9 @@
 jest.mock( "child_process", () => ( {
 	exec: jest.fn( ( command, cb ) => {
 		cb( null, "success" );
+	} ),
+	execSync: jest.fn( command => {
+		return "https://puppet.leankit.com:4873";
 	} )
 } ) );
 
@@ -903,6 +906,25 @@ describe( "utils", () => {
 			util.advise( "hello world", { exit: false } );
 			expect( process.exit ).toHaveBeenCalledTimes( 1 );
 			expect( console.log ).toHaveBeenCalledTimes( 1 ); // eslint-disable-line no-console
+		} );
+	} );
+
+	describe( "hasLkScope", () => {
+		it( "should run `child_process.execSync", () => {
+			util.hasLkScope();
+			expect( cp.execSync ).toHaveBeenCalledTimes( 1 );
+			expect( cp.execSync ).toHaveBeenCalledWith( "npm config get @lk:registry" );
+		} );
+
+		it( `should return true when the user has a registry for the "@lk" scope`, () => {
+			const isLK = util.hasLkScope();
+			expect( isLK ).toBeTruthy();
+		} );
+
+		it( `should return false when the user has no registry for the "@lk" scope`, () => {
+			cp.execSync = jest.fn( command => "undefined" );
+			const isLK = util.hasLkScope();
+			expect( isLK ).toBeFalsy();
 		} );
 	} );
 } );

--- a/src/help.js
+++ b/src/help.js
@@ -1,0 +1,36 @@
+import chalk from "chalk";
+import util from "./utils";
+
+const { hasLkScope, renderHelpContent } = util;
+
+let helpContent = `
+  Examples:
+
+    $ tag-release
+    $ tag-release --config ../../config.json
+    $ tag-release -c ./manifest.json
+    $ tag-release --release major
+    $ tag-release -r minor
+    $ tag-release --prerelease
+    $ tag-release -p -i rc
+    $ tag-release --reset
+    $ tag-release --verbose
+    $ tag-release -v
+    $ tag-release --promote
+    $ tag-release --promote v1.1.1-my-tagged-version.0
+    $ tag-release --continue
+    $ tag-release --qa
+    $ tag-release --qa myorg
+    $ tag-release --pr
+    $ tag-release --pr myorg
+
+  Link to README: ${ chalk.yellow.underline.bold( "https://github.com/LeanKit-Labs/tag-release/blob/master/README.md" ) }
+`;
+
+if ( hasLkScope() ) {
+	helpContent = `${ helpContent }  LeanKit tag-release workflow: ${ chalk.green.underline.bold( "https://leankit-wiki.atlassian.net/wiki/spaces/PD/pages/96347952/tag-release+workflow" ) }\n`;
+}
+
+const help = () => renderHelpContent( helpContent );
+
+export default help;

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import _ from "lodash";
 import utils from "./utils.js";
 import chalk from "chalk";
 import tagRelease from "./tag-release";
+import help from "./help";
 import logger from "better-console";
 import fmt from "fmt";
 import pkg from "../package.json";
@@ -39,29 +40,7 @@ commander
 	.option( "--qa [scope]", "Create initial upstream branch for lightning." )
 	.option( "--pr [scope]", "Update lightning branch and create a PR to develop." );
 
-commander.on( "--help", () => {
-	console.log( "" );
-	console.log( "  Examples: \n" );
-	console.log( "    $ tag-release" );
-	console.log( "    $ tag-release --config ../../config.json" );
-	console.log( "    $ tag-release -c ./manifest.json" );
-	console.log( "    $ tag-release --release major" );
-	console.log( "    $ tag-release -r minor" );
-	console.log( "    $ tag-release --prerelease" );
-	console.log( "    $ tag-release -p -i rc" );
-	console.log( "    $ tag-release --reset" );
-	console.log( "    $ tag-release --verbose" );
-	console.log( "    $ tag-release -v" );
-	console.log( "    $ tag-release --promote" );
-	console.log( "    $ tag-release --promote v1.1.1-my-tagged-version.0" );
-	console.log( "    $ tag-release --continue" );
-	console.log( "    $ tag-release --qa" );
-	console.log( "    $ tag-release --qa myorg" );
-	console.log( "    $ tag-release --pr" );
-	console.log( "    $ tag-release --pr myorg" );
-	console.log( "" );
-	console.log( `Link to README: ${ chalk.yellow.underline.bold( "https://github.com/LeanKit-Labs/tag-release/blob/master/README.md" ) } ` );
-} );
+commander.on( "--help", () => help() );
 
 commander.parse( process.argv );
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -280,5 +280,18 @@ export default {
 		if ( exit ) {
 			process.exit( 0 ); // eslint-disable-line no-process-exit
 		}
+	},
+	hasLkScope() {
+		const GET_LK_REGISTRY_SCOPE = "npm config get @lk:registry";
+		const run = command => childProcess.execSync( command ).toString().trim();
+		return run( GET_LK_REGISTRY_SCOPE ) !== "undefined";
+	},
+	renderHelpContent( content ) {
+		// mocking console.log is not awesome, and this function only exists
+		// for the purpose of avoiding having to mock console.log in tests,
+		// so we're just going to go ahead and safely ignore this in coverage
+
+		/* istanbul ignore next */
+		console.log( content ); // eslint-disable-line no-console
 	}
 };


### PR DESCRIPTION
### Short description of the work completed

> This PR adds code to check for the `@lk` registry scope in the user's npm config, and if it exists, the help output will include a hyperlink to a page documenting the LeanKit tag-release workflow on the LeanKit wiki. The link should not be shown when the user does _not_ have the `@lk` registry scope in their npm config.

### Steps to test (if not obvious)

1. Run  `tag-release --help`
2. You should see a link to the LeanKit tag-release workflow doc on the wiki at the bottom of the help output.
3. Edit your global `.npmrc` file to temporarily comment out the `@lk` registry scope
4. Run `tag-release --help` again
5. This time, you should NOT see the link at the bottom of the help output

**NOTE**: REMEMBER to go back and uncomment your `.npmrc` file to make sure you add the `@lk` scope back in to it.

### For Reviewer Use Only

- [x] Code Reviewed
- [x] Tests Passed
- [x] Coverage Reviewed
- [x] Feature worked as expected
- [x] Added or updated flags to `--help` and `README.md`
- [x] Does the feature work in Windows PowerShell?
- [x] Is the version upgrade path clear for this change? (breaking vs minor vs
  patch)
- [x] Follow up work tracked in a card if needed
