### PR TITLE
Feature varies fixes

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
-  "presets": [ "es2015", "stage-0" ],
+  "presets": [ "env" , "stage-0" ],
   "sourceMaps": "inline",
   "env": {
     "test": {

--- a/package.json
+++ b/package.json
@@ -32,9 +32,7 @@
   },
   "dependencies": {
     "babel-plugin-captains-log": "^0.6.0",
-    "babel-preset-es2015": "^6.6.0",
     "babel-preset-stage-0": "^6.3.13",
-    "babel-preset-stage-2": "^6.3.13",
     "babel-register": "^6.11.6",
     "better-console": "^0.2.4",
     "chalk": "^1.1.3",
@@ -57,6 +55,7 @@
   "devDependencies": {
     "eslint-config-leankit": "^4.3.0",
     "husky": "^0.14.3",
+    "babel-preset-env": "^1.6.0",
     "jest": "^20.0.4",
     "lint-staged": "^4.2.3",
     "prettier": "^1.7.4"

--- a/specs/utils.spec.js
+++ b/specs/utils.spec.js
@@ -282,6 +282,18 @@ describe("utils", () => {
 		});
 	});
 
+	describe("fileExists", () => {
+		it("should return true if file exists", () => {
+			fs.existsSync = jest.fn().mockReturnValue(true);
+			expect(util.fileExists("./some_path/file.txt")).toBeTruthy();
+		});
+
+		it("should return false if file doesn't exists", () => {
+			fs.existsSync = jest.fn().mockReturnValue(false);
+			expect(util.fileExists(null)).toBeFalsy();
+		});
+	});
+
 	describe("exec", () => {
 		it("should return a promise", () => {
 			const result = util.exec(`say "test"`);

--- a/specs/workflows/reset.spec.js
+++ b/specs/workflows/reset.spec.js
@@ -4,6 +4,10 @@ import * as run from "../../src/workflows/steps";
 describe("reset workflow", () => {
 	it("should have all of the required steps", () => {
 		expect(resetWorkflow).toEqual([
+			run.verifyRemotes,
+			run.verifyOrigin,
+			run.githubOrigin,
+			run.verifyUpstream,
 			run.gitFetchUpstream,
 			run.checkHasDevelopBranch,
 			run.checkForUncommittedChanges,
@@ -15,6 +19,8 @@ describe("reset workflow", () => {
 			run.verifyDevelopBranch,
 			run.gitCheckoutDevelop,
 			run.gitResetDevelop,
+			run.verifyPackageJson,
+			run.verifyChangelog,
 			run.cleanUpTmpFiles
 		]);
 	});

--- a/specs/workflows/steps/index.spec.js
+++ b/specs/workflows/steps/index.spec.js
@@ -1250,6 +1250,16 @@ describe("shared workflow steps", () => {
 	});
 
 	describe("githubOrigin", () => {
+		beforeEach(() => {
+			state = {
+				remotes: {
+					origin: {
+						exists: true
+					}
+				}
+			};
+		});
+
 		it("should call `util.exec` with the appropriate arguments to get the origin repository url", () => {
 			util.exec = jest.fn(() =>
 				Promise.resolve("https://github.com/leankit-labs/tag-release.git")
@@ -1279,6 +1289,12 @@ describe("shared workflow steps", () => {
 						github: {
 							owner: "leankit-labs",
 							name: "tag-release"
+						},
+						remotes: {
+							origin: {
+								exists: true,
+								url: "https://github.com/leankit-labs/tag-release.git"
+							}
 						}
 					});
 				});
@@ -1290,11 +1306,17 @@ describe("shared workflow steps", () => {
 						"https://github.com/banditsoftware/web-lightning-ui.git"
 					)
 				);
-				return run.githubUpstream(state).then(() => {
+				return run.githubOrigin(state).then(() => {
 					expect(state).toEqual({
 						github: {
 							owner: "banditsoftware",
 							name: "web-lightning-ui"
+						},
+						remotes: {
+							origin: {
+								exists: true,
+								url: "https://github.com/banditsoftware/web-lightning-ui.git"
+							}
 						}
 					});
 				});
@@ -1311,6 +1333,12 @@ describe("shared workflow steps", () => {
 						github: {
 							owner: "leankit-labs",
 							name: "tag-release"
+						},
+						remotes: {
+							origin: {
+								exists: true,
+								url: "git@github.com:leankit-labs/tag-release.git"
+							}
 						}
 					});
 				});
@@ -1320,11 +1348,17 @@ describe("shared workflow steps", () => {
 				util.exec = jest.fn(() =>
 					Promise.resolve("git@github.com:banditsoftware/web-lightning-ui.git")
 				);
-				return run.githubUpstream(state).then(() => {
+				return run.githubOrigin(state).then(() => {
 					expect(state).toEqual({
 						github: {
 							owner: "banditsoftware",
 							name: "web-lightning-ui"
+						},
+						remotes: {
+							origin: {
+								exists: true,
+								url: "git@github.com:banditsoftware/web-lightning-ui.git"
+							}
 						}
 					});
 				});
@@ -1335,7 +1369,18 @@ describe("shared workflow steps", () => {
 			it("should set the github object on state to an empty object", () => {
 				util.exec = jest.fn(() => Promise.resolve(""));
 				return run.githubOrigin(state).then(() => {
-					expect(state).toEqual({ github: {} });
+					expect(state).toEqual({
+						github: {
+							owner: undefined,
+							name: undefined
+						},
+						remotes: {
+							origin: {
+								exists: true,
+								url: ""
+							}
+						}
+					});
 				});
 			});
 		});
@@ -2747,8 +2792,8 @@ describe("shared workflow steps", () => {
 				return run.verifyRemotes(state).then(() => {
 					expect(state.remotes).toHaveProperty("origin");
 					expect(state.remotes).toHaveProperty("upstream");
-					expect(state.remotes.origin).toEqual(true);
-					expect(state.remotes.upstream).toEqual(true);
+					expect(state.remotes.origin.exists).toEqual(true);
+					expect(state.remotes.upstream.exists).toEqual(true);
 				});
 			});
 
@@ -2757,8 +2802,8 @@ describe("shared workflow steps", () => {
 				return run.verifyRemotes(state).then(() => {
 					expect(state.remotes).toHaveProperty("origin");
 					expect(state.remotes).toHaveProperty("upstream");
-					expect(state.remotes.origin).toEqual(false);
-					expect(state.remotes.upstream).toEqual(false);
+					expect(state.remotes.origin.exists).toEqual(false);
+					expect(state.remotes.upstream.exists).toEqual(false);
 				});
 			});
 
@@ -2767,8 +2812,8 @@ describe("shared workflow steps", () => {
 				return run.verifyRemotes(state).then(() => {
 					expect(state.remotes).toHaveProperty("origin");
 					expect(state.remotes).toHaveProperty("upstream");
-					expect(state.remotes.origin).toEqual(false);
-					expect(state.remotes.upstream).toEqual(true);
+					expect(state.remotes.origin.exists).toEqual(false);
+					expect(state.remotes.upstream.exists).toEqual(true);
 				});
 			});
 
@@ -2777,8 +2822,8 @@ describe("shared workflow steps", () => {
 				return run.verifyRemotes(state).then(() => {
 					expect(state.remotes).toHaveProperty("origin");
 					expect(state.remotes).toHaveProperty("upstream");
-					expect(state.remotes.origin).toEqual(true);
-					expect(state.remotes.upstream).toEqual(false);
+					expect(state.remotes.origin.exists).toEqual(true);
+					expect(state.remotes.upstream.exists).toEqual(false);
 				});
 			});
 		});
@@ -2788,7 +2833,9 @@ describe("shared workflow steps", () => {
 		beforeEach(() => {
 			state = {
 				remotes: {
-					origin: true
+					origin: {
+						exists: true
+					}
 				}
 			};
 		});
@@ -2809,7 +2856,9 @@ describe("shared workflow steps", () => {
 		it("should advise when remote origin doesn't exists", () => {
 			state = {
 				remotes: {
-					origin: false
+					origin: {
+						exists: false
+					}
 				}
 			};
 
@@ -2831,7 +2880,8 @@ describe("shared workflow steps", () => {
 						Promise.resolve({
 							data: {
 								parent: {
-									ssh_url: "git@github.com:johndoe/hasParent-repo.git"
+									ssh_url: "git@github.com:johndoe/hasParent-repo.git",
+									svn_url: "https://github.com/johndoe/noParent-repo.git"
 								}
 							}
 						})
@@ -2840,7 +2890,8 @@ describe("shared workflow steps", () => {
 					getDetails = jest.fn(() =>
 						Promise.resolve({
 							data: {
-								ssh_url: "git@github.com:johndoe/noParent-repo.git"
+								ssh_url: "git@github.com:johndoe/noParent-repo.git",
+								svn_url: "https://github.com/johndoe/noParent-repo.git"
 							}
 						})
 					);
@@ -2867,7 +2918,15 @@ describe("shared workflow steps", () => {
 			state = {
 				github: { owner: "someone-awesome", name: "something-awesome" },
 				token: "z8259r",
-				remotes: { upstream: false }
+				remotes: {
+					origin: {
+						exists: true,
+						url: "git@github.com:johnsmith/awesome-repo.git"
+					},
+					upstream: {
+						exists: false
+					}
+				}
 			};
 			util.exec = jest.fn(() => Promise.resolve(""));
 			GitHub.mockImplementation(mockGitHub());
@@ -2894,7 +2953,7 @@ describe("shared workflow steps", () => {
 
 		describe("when upstream remote exists", () => {
 			it("should log the action to console", () => {
-				state.remotes.upstream = true;
+				state.remotes.upstream.exists = true;
 
 				return run.verifyUpstream(state).then(() => {
 					expect(util.log.begin).toHaveBeenCalledTimes(1);
@@ -2927,6 +2986,33 @@ describe("shared workflow steps", () => {
 							"git remote add upstream git@github.com:johndoe/noParent-repo.git"
 						);
 					});
+				});
+
+				describe("when using svn_url", () => {
+					it("should create remote upstream", () => {
+						state.remotes.origin.url =
+							"https://github.com/johndoe/noParent-repo.git";
+						GitHub.mockImplementation(mockGitHub(true, false));
+
+						return run.verifyUpstream(state).then(() => {
+							expect(util.exec).toHaveBeenCalledTimes(1);
+							expect(util.exec).toHaveBeenCalledWith(
+								"git remote add upstream https://github.com/johndoe/noParent-repo.git"
+							);
+						});
+					});
+				});
+			});
+
+			it("should create remote upstream with svn_url", () => {
+				state.remotes.origin.url =
+					"https://github.com/johndoe/noParent-repo.git";
+
+				return run.verifyUpstream(state).then(() => {
+					expect(util.exec).toHaveBeenCalledTimes(1);
+					expect(util.exec).toHaveBeenCalledWith(
+						"git remote add upstream https://github.com/johndoe/noParent-repo.git"
+					);
 				});
 			});
 		});

--- a/specs/workflows/steps/index.spec.js
+++ b/specs/workflows/steps/index.spec.js
@@ -203,7 +203,7 @@ describe("shared workflow steps", () => {
 					{
 						type: "input",
 						name: "prereleaseIdentifier",
-						message: "Pre-release Identifier:"
+						message: "What is your pre-release Identifier?"
 					}
 				]);
 			});
@@ -259,7 +259,7 @@ describe("shared workflow steps", () => {
 					{
 						type: "list",
 						name: "prereleaseToPromote",
-						message: "Select the pre-release you wish to promote:",
+						message: "Which pre-release do you wish to promote?",
 						choices: [
 							"v18.0.0-robert.0",
 							"v17.12.0-break.1",
@@ -524,7 +524,7 @@ describe("shared workflow steps", () => {
 						{
 							type: "list",
 							name: "release",
-							message: "What type of release is this",
+							message: "What type of release is this?",
 							choices: [
 								{
 									name: "Major (Breaking Change) v2.0.0",
@@ -558,7 +558,7 @@ describe("shared workflow steps", () => {
 						{
 							type: "list",
 							name: "release",
-							message: "What type of release is this",
+							message: "What type of release is this?",
 							choices: [
 								{
 									name: "Pre-major (Breaking Change) v2.0.0-test.0",
@@ -638,7 +638,7 @@ describe("shared workflow steps", () => {
 					{
 						type: "confirm",
 						name: "log",
-						message: "Would you like to edit your log",
+						message: "Would you like to edit your log?",
 						default: true
 					}
 				]);
@@ -1249,6 +1249,98 @@ describe("shared workflow steps", () => {
 		});
 	});
 
+	describe("githubOrigin", () => {
+		it("should call `util.exec` with the appropriate arguments to get the origin repository url", () => {
+			util.exec = jest.fn(() =>
+				Promise.resolve("https://github.com/leankit-labs/tag-release.git")
+			);
+			return run.githubOrigin(state).then(() => {
+				expect(util.exec).toHaveBeenCalledTimes(1);
+				expect(util.exec).toHaveBeenCalledWith("git config remote.origin.url");
+			});
+		});
+
+		it("should log an error to the console when the call to `util.exec` fails", () => {
+			util.exec = jest.fn(() => Promise.reject("nope"));
+			logger.log = jest.fn(() => {});
+			return run.githubOrigin(state).then(() => {
+				expect(logger.log).toHaveBeenCalledTimes(1);
+				expect(logger.log).toHaveBeenCalledWith("error", "nope");
+			});
+		});
+
+		describe("when an https uri is returned", () => {
+			it("should extract the correct repository owner and name given https://github.com/leanKit-labs/tag-release.git", () => {
+				util.exec = jest.fn(() =>
+					Promise.resolve("https://github.com/leankit-labs/tag-release.git")
+				);
+				return run.githubOrigin(state).then(() => {
+					expect(state).toEqual({
+						github: {
+							owner: "leankit-labs",
+							name: "tag-release"
+						}
+					});
+				});
+			});
+
+			it("should extract the correct repository owner and name given https://github.com/banditsoftware/web-lightning-ui.git", () => {
+				util.exec = jest.fn(() =>
+					Promise.resolve(
+						"https://github.com/banditsoftware/web-lightning-ui.git"
+					)
+				);
+				return run.githubUpstream(state).then(() => {
+					expect(state).toEqual({
+						github: {
+							owner: "banditsoftware",
+							name: "web-lightning-ui"
+						}
+					});
+				});
+			});
+		});
+
+		describe("when an ssh uri is returned", () => {
+			it("should extract the correct repository owner and name given git@github.com:leankit-labs/tag-release.git", () => {
+				util.exec = jest.fn(() =>
+					Promise.resolve("git@github.com:leankit-labs/tag-release.git")
+				);
+				return run.githubOrigin(state).then(() => {
+					expect(state).toEqual({
+						github: {
+							owner: "leankit-labs",
+							name: "tag-release"
+						}
+					});
+				});
+			});
+
+			it("should extract the correct repository owner and name given git@github.com:banditsoftware/web-lightning-ui.git", () => {
+				util.exec = jest.fn(() =>
+					Promise.resolve("git@github.com:banditsoftware/web-lightning-ui.git")
+				);
+				return run.githubUpstream(state).then(() => {
+					expect(state).toEqual({
+						github: {
+							owner: "banditsoftware",
+							name: "web-lightning-ui"
+						}
+					});
+				});
+			});
+		});
+
+		describe("when no data is returned", () => {
+			it("should set the github object on state to an empty object", () => {
+				util.exec = jest.fn(() => Promise.resolve(""));
+				return run.githubOrigin(state).then(() => {
+					expect(state).toEqual({ github: {} });
+				});
+			});
+		});
+	});
+
 	describe("githubRelease", () => {
 		GitHub.mockImplementation(jest.fn());
 		let getRepo = jest.fn();
@@ -1769,7 +1861,7 @@ describe("shared workflow steps", () => {
 					{
 						type: "checkbox",
 						name: "packagesToPromote",
-						message: "Select the package(s) you wish to update:",
+						message: "Which package(s) do you wish to update?",
 						choices: ["over-watch", "watch-over"]
 					}
 				]);
@@ -1934,7 +2026,7 @@ describe("shared workflow steps", () => {
 					{
 						type: "list",
 						name: "changeType",
-						message: "What type of change is this work",
+						message: "What type of change is this work?",
 						choices: ["feature", "defect", "rework"]
 					}
 				]);
@@ -1946,6 +2038,28 @@ describe("shared workflow steps", () => {
 				expect(state).toHaveProperty("changeType");
 				expect(state.changeType).toEqual("feature");
 			});
+		});
+	});
+
+	describe("changeReasonValidator", () => {
+		let changeReason;
+
+		beforeEach(() => {
+			changeReason = "this is some reason";
+		});
+
+		it("should return true with value", () => {
+			expect(run.changeReasonValidator(changeReason)).toEqual(true);
+		});
+
+		it("should return false with no value", () => {
+			changeReason = "";
+			expect(run.changeReasonValidator(changeReason)).toEqual(false);
+		});
+
+		it("should return false with whitespace", () => {
+			changeReason = "     ";
+			expect(run.changeReasonValidator(changeReason)).toEqual(false);
 		});
 	});
 
@@ -1963,7 +2077,8 @@ describe("shared workflow steps", () => {
 					{
 						type: "input",
 						name: "changeReason",
-						message: "What is the reason for this change"
+						message: "What is the reason for this change? (required)",
+						validate: run.changeReasonValidator
 					}
 				]);
 			});
@@ -2613,6 +2728,299 @@ describe("shared workflow steps", () => {
 			return run.getTagsFromRepo(state).then(() => {
 				expect(logger.log).toHaveBeenCalledTimes(1);
 				expect(logger.log).toHaveBeenCalledWith("listTags fail");
+			});
+		});
+	});
+
+	describe("verifyRemotes", () => {
+		it("should call `util.exec` with the appropriate arguments to get the remotes", () => {
+			util.exec = jest.fn(() => Promise.resolve(""));
+			return run.verifyRemotes(state).then(() => {
+				expect(util.exec).toHaveBeenCalledTimes(1);
+				expect(util.exec).toHaveBeenCalledWith("git remote");
+			});
+		});
+
+		describe("when setting state", () => {
+			it("should set origin and upstream to true", () => {
+				util.exec = jest.fn(() => Promise.resolve("origin\nupstream\n"));
+				return run.verifyRemotes(state).then(() => {
+					expect(state.remotes).toHaveProperty("origin");
+					expect(state.remotes).toHaveProperty("upstream");
+					expect(state.remotes.origin).toEqual(true);
+					expect(state.remotes.upstream).toEqual(true);
+				});
+			});
+
+			it("should set origin and upstream to false", () => {
+				util.exec = jest.fn(() => Promise.resolve(""));
+				return run.verifyRemotes(state).then(() => {
+					expect(state.remotes).toHaveProperty("origin");
+					expect(state.remotes).toHaveProperty("upstream");
+					expect(state.remotes.origin).toEqual(false);
+					expect(state.remotes.upstream).toEqual(false);
+				});
+			});
+
+			it("should set origin to false and upstream to true", () => {
+				util.exec = jest.fn(() => Promise.resolve("upstream\n"));
+				return run.verifyRemotes(state).then(() => {
+					expect(state.remotes).toHaveProperty("origin");
+					expect(state.remotes).toHaveProperty("upstream");
+					expect(state.remotes.origin).toEqual(false);
+					expect(state.remotes.upstream).toEqual(true);
+				});
+			});
+
+			it("should set origin to true and upstream to false", () => {
+				util.exec = jest.fn(() => Promise.resolve("origin\n"));
+				return run.verifyRemotes(state).then(() => {
+					expect(state.remotes).toHaveProperty("origin");
+					expect(state.remotes).toHaveProperty("upstream");
+					expect(state.remotes.origin).toEqual(true);
+					expect(state.remotes.upstream).toEqual(false);
+				});
+			});
+		});
+	});
+
+	describe("verifyOrigin", () => {
+		beforeEach(() => {
+			state = {
+				remotes: {
+					origin: true
+				}
+			};
+		});
+		it("should resolve when remote origin exists", () => {
+			return run.verifyOrigin(state).then(() => {
+				expect(util.advise).not.toHaveBeenCalled();
+			});
+		});
+
+		it("should log the action to the console", () => {
+			return run.verifyOrigin(state).then(() => {
+				expect(util.log.begin).toHaveBeenCalledTimes(1);
+				expect(util.log.begin).toHaveBeenCalledWith("Verifying origin remote");
+				expect(util.log.end).toHaveBeenCalledTimes(1);
+			});
+		});
+
+		it("should advise when remote origin doesn't exists", () => {
+			state = {
+				remotes: {
+					origin: false
+				}
+			};
+
+			return run.verifyOrigin(state).then(() => {
+				expect(util.advise).toHaveBeenCalledTimes(1);
+				expect(util.advise).toHaveBeenCalledWith("gitOrigin");
+			});
+		});
+	});
+
+	describe("verifyUpstream", () => {
+		let getRepo = jest.fn();
+		let getDetails = jest.fn();
+
+		const mockGetDetails = (shouldResolve = true, hasParent = true) => {
+			if (shouldResolve) {
+				if (hasParent) {
+					getDetails = jest.fn(() =>
+						Promise.resolve({
+							data: {
+								parent: {
+									ssh_url: "git@github.com:johndoe/hasParent-repo.git"
+								}
+							}
+						})
+					);
+				} else {
+					getDetails = jest.fn(() =>
+						Promise.resolve({
+							data: {
+								ssh_url: "git@github.com:johndoe/noParent-repo.git"
+							}
+						})
+					);
+				}
+
+				return getDetails;
+			}
+
+			getDetails = jest.fn(() => Promise.reject("getDetails fail"));
+
+			return getDetails;
+		};
+
+		const mockGitHub = (getDetailsShouldResolve = true, hasParent = true) => {
+			getDetails = mockGetDetails(getDetailsShouldResolve, hasParent);
+			getRepo = jest.fn(() => ({
+				getDetails
+			}));
+
+			return jest.fn(() => ({ getRepo }));
+		};
+
+		beforeEach(() => {
+			state = {
+				github: { owner: "someone-awesome", name: "something-awesome" },
+				token: "z8259r",
+				remotes: { upstream: false }
+			};
+			util.exec = jest.fn(() => Promise.resolve(""));
+			GitHub.mockImplementation(mockGitHub());
+		});
+
+		it("should log an error to the console when the call to `util.exec` fails", () => {
+			util.exec = jest.fn(() => Promise.reject("nope"));
+			logger.log = jest.fn(() => {});
+			return run.verifyUpstream(state).then(() => {
+				expect(logger.log).toHaveBeenCalledTimes(1);
+				expect(logger.log).toHaveBeenCalledWith("nope");
+			});
+		});
+
+		it("should log an error to the console when the call to the API to get detailss fails", () => {
+			logger.log = jest.fn();
+			GitHub.mockImplementation(mockGitHub(false));
+
+			return run.verifyUpstream(state).then(() => {
+				expect(logger.log).toHaveBeenCalledTimes(1);
+				expect(logger.log).toHaveBeenCalledWith("getDetails fail");
+			});
+		});
+
+		describe("when upstream remote exists", () => {
+			it("should log the action to console", () => {
+				state.remotes.upstream = true;
+
+				return run.verifyUpstream(state).then(() => {
+					expect(util.log.begin).toHaveBeenCalledTimes(1);
+					expect(util.log.begin).toHaveBeenCalledWith(
+						"Verifying upstream remote"
+					);
+					expect(util.log.end).toHaveBeenCalledTimes(1);
+				});
+			});
+		});
+
+		describe("when upstream remote doesn't exist", () => {
+			it("should log the action to console", () => {
+				return run.verifyUpstream(state).then(() => {
+					expect(util.log.begin).toHaveBeenCalledTimes(2);
+					expect(util.log.begin).toHaveBeenCalledWith(
+						"Creating upstream remote"
+					);
+					expect(util.log.end).toHaveBeenCalledTimes(2);
+				});
+			});
+
+			describe("when repository is parent", () => {
+				it("should create remote upstream", () => {
+					GitHub.mockImplementation(mockGitHub(true, false));
+
+					return run.verifyUpstream(state).then(() => {
+						expect(util.exec).toHaveBeenCalledTimes(1);
+						expect(util.exec).toHaveBeenCalledWith(
+							"git remote add upstream git@github.com:johndoe/noParent-repo.git"
+						);
+					});
+				});
+			});
+		});
+	});
+
+	describe("verifyChangelog", () => {
+		beforeEach(() => {
+			util.fileExists = jest.fn(() => false);
+			util.writeFile = jest.fn(() => {});
+			util.prompt = jest.fn(() => Promise.resolve({ changelog: true }));
+		});
+
+		describe("when CHANGELOG.md exists", () => {
+			it("should log the action to the console", () => {
+				util.fileExists = jest.fn(() => true);
+				return run.verifyChangelog(state).then(() => {
+					expect(util.log.begin).toHaveBeenCalledTimes(1);
+					expect(util.log.begin).toHaveBeenCalledWith("Verifying CHANGELOG.md");
+					expect(util.log.end).toHaveBeenCalledTimes(1);
+				});
+			});
+		});
+
+		describe("when CHANGELOG.md doesn't exist", () => {
+			it("should prompt user", () => {
+				return run.verifyChangelog(state).then(() => {
+					expect(util.prompt).toHaveBeenCalledTimes(1);
+					expect(util.prompt).toHaveBeenCalledWith([
+						{
+							type: "confirm",
+							name: "changelog",
+							message: "Would you like us to create a CHANGELOG.md?",
+							default: true
+						}
+					]);
+				});
+			});
+
+			it("should log the action to the console", () => {
+				return run.verifyChangelog(state).then(() => {
+					expect(util.log.begin).toHaveBeenCalledTimes(2);
+					expect(util.log.begin).toHaveBeenCalledWith("Creating CHANGELOG.md");
+					expect(util.log.end).toHaveBeenCalledTimes(2);
+				});
+			});
+
+			it("should create CHANGELOG.md", () => {
+				util.prompt = jest.fn(() => Promise.resolve({ changelog: true }));
+				return run.verifyChangelog(state).then(() => {
+					expect(util.writeFile).toHaveBeenCalledTimes(1);
+				});
+			});
+
+			it("should not create CHANGELOG.md", () => {
+				util.prompt = jest.fn(() => Promise.resolve({ changelog: false }));
+				return run.verifyChangelog(state).then(() => {
+					expect(util.writeFile).not.toHaveBeenCalled();
+				});
+			});
+		});
+	});
+
+	describe("verifyPackageJson", () => {
+		beforeEach(() => {
+			state = {
+				configPath: "./some_path"
+			};
+			util.advise = jest.fn(() => Promise.resolve());
+			util.fileExists = jest.fn(() => true);
+		});
+
+		it("should log the action to the console", () => {
+			return run.verifyPackageJson(state).then(() => {
+				expect(util.log.begin).toHaveBeenCalledTimes(1);
+				expect(util.log.begin).toHaveBeenCalledWith("Verifying package.json");
+				expect(util.log.end).toHaveBeenCalledTimes(1);
+			});
+		});
+
+		describe("when configPath exists", () => {
+			it("should not advise", () => {
+				return run.verifyPackageJson(state).then(() => {
+					expect(util.advise).not.toHaveBeenCalled();
+				});
+			});
+		});
+
+		describe("when configPath doesn't exist", () => {
+			it("should advise", () => {
+				util.fileExists = jest.fn(() => false);
+				return run.verifyPackageJson(state).then(() => {
+					expect(util.advise).toHaveBeenCalledTimes(1);
+					expect(util.advise).toHaveBeenCalledWith("missingPackageJson");
+				});
 			});
 		});
 	});

--- a/src/advise.js
+++ b/src/advise.js
@@ -55,6 +55,11 @@ You might consider reseting your branch by running 'git reset --hard upstream/de
 tag-release needs an upstream remote in order to work correctly. You can double check by running 'git remote -v'
 
 To add a remote run 'git remote add upstream https://github.com/owner/repo.git'`,
+	gitOrigin: `It appears we couldn't access your remote origin repository.
+
+To add a remote origin run 'git remote add origin https://github.com/username/repo.git'
+
+You can double check by running 'git remote -v'`,
 	gitRebaseInteractive: `It looks like there was some conflict(s) while trying to rebase with upstream/master.
 
 Unfortunately, tag-release can't auto-magically fix them. Please fix the conflict at hand and then run 'tag-release --continue'. Tag-release
@@ -69,7 +74,12 @@ Please fix all conflict markers with the current conflict before running 'tag-re
 You really shouldn't be seeing this message, so, if you are, ping someone in engineering to see if they can help you figure out what went wrong.`,
 	gitMergeUpstreamBranch: `It appears that when trying to merge with the upstream branch something went wrong.
 
-Either you don't have an upstream with the same name as your local, or we weren't able to 'merge --ff-only' on your local branch with the upstream.`
+Either you don't have an upstream with the same name as your local, or we weren't able to 'merge --ff-only' on your local branch with the upstream.`,
+	missingPackageJson: `It appears you do not have a package.json. A package.json is required to use tag-release.
+
+You can use the 'npm init' command to generate a package.json for you.
+
+Alternatively, You can specifiy a different config file by using the -c command: 'tag-release -c another.json'`
 };
 
 const MAXIMUM_WIDTH = 50;

--- a/src/index.js
+++ b/src/index.js
@@ -76,7 +76,9 @@ export function startTagRelease(options) {
 		options = _.extend({}, commander, options);
 		options.configPath = options.config || "./package.json";
 
-		return tagRelease(options);
+		return tagRelease(options).catch(error => {
+			console.log(`Tag-release encountered a problem: ${error}`);
+		});
 	} catch (error) {
 		console.log(`Tag-release encountered a problem: ${error}`);
 	}

--- a/src/utils.js
+++ b/src/utils.js
@@ -48,6 +48,9 @@ export default {
 	deleteFile(path) {
 		return fs.existsSync(path) ? fs.unlink(path) : Promise.resolve();
 	},
+	fileExists(path) {
+		return fs.existsSync(path) ? true : false;
+	},
 	exec(command) {
 		return new Promise((resolve, reject) =>
 			childProcess.exec(command, (error, stdout) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -49,7 +49,7 @@ export default {
 		return fs.existsSync(path) ? fs.unlink(path) : Promise.resolve();
 	},
 	fileExists(path) {
-		return fs.existsSync(path) ? true : false;
+		return fs.existsSync(path);
 	},
 	exec(command) {
 		return new Promise((resolve, reject) =>

--- a/src/workflows/reset.js
+++ b/src/workflows/reset.js
@@ -1,6 +1,10 @@
 import * as run from "./steps/index";
 
 export default [
+	run.verifyRemotes,
+	run.verifyOrigin,
+	run.githubOrigin,
+	run.verifyUpstream,
 	run.gitFetchUpstream,
 	run.checkHasDevelopBranch,
 	run.checkForUncommittedChanges,
@@ -12,5 +16,7 @@ export default [
 	run.verifyDevelopBranch,
 	run.gitCheckoutDevelop,
 	run.gitResetDevelop,
+	run.verifyPackageJson,
+	run.verifyChangelog,
 	run.cleanUpTmpFiles
 ];

--- a/src/workflows/steps/index.js
+++ b/src/workflows/steps/index.js
@@ -70,7 +70,7 @@ export function setPrereleaseIdentifier(state) {
 			{
 				type: "input",
 				name: "prereleaseIdentifier",
-				message: "Pre-release Identifier:"
+				message: "What is your pre-release Identifier?"
 			}
 		])
 		.then(response => {
@@ -87,7 +87,7 @@ export function selectPrereleaseToPromote(state) {
 					{
 						type: "list",
 						name: "prereleaseToPromote",
-						message: "Select the pre-release you wish to promote:",
+						message: "Which pre-release do you wish to promote?",
 						choices: prereleases
 					}
 				])
@@ -201,7 +201,7 @@ export function askSemverJump(state) {
 			{
 				type: "list",
 				name: "release",
-				message: "What type of release is this",
+				message: "What type of release is this?",
 				choices
 			}
 		])
@@ -217,7 +217,7 @@ export function updateLog(state) {
 			{
 				type: "confirm",
 				name: "log",
-				message: "Would you like to edit your log",
+				message: "Would you like to edit your log?",
 				default: true
 			}
 		])
@@ -619,7 +619,7 @@ export function askReposToUpdate(state) {
 				{
 					type: "checkbox",
 					name: "packagesToPromote",
-					message: "Select the package(s) you wish to update:",
+					message: "Which package(s) do you wish to update?",
 					choices: packages
 				}
 			])
@@ -684,7 +684,7 @@ export function askChangeType(state) {
 			{
 				type: "list",
 				name: "changeType",
-				message: "What type of change is this work",
+				message: "What type of change is this work?",
 				choices: ["feature", "defect", "rework"]
 			}
 		])
@@ -700,7 +700,10 @@ export function askChangeReason(state) {
 			{
 				type: "input",
 				name: "changeReason",
-				message: "What is the reason for this change"
+				message: `What is the reason for this change? ${chalk.red(
+					"(required)"
+				)}`,
+				validate: changeReason => changeReason.trim().length > 0
 			}
 		])
 		.then(({ changeReason }) => {
@@ -985,7 +988,7 @@ export function verifyChangelog() {
 			{
 				type: "confirm",
 				name: "changelog",
-				message: "Would you like us to create a CHANGELOG.md",
+				message: "Would you like us to create a CHANGELOG.md?",
 				default: true
 			}
 		])

--- a/src/workflows/steps/index.js
+++ b/src/workflows/steps/index.js
@@ -694,6 +694,10 @@ export function askChangeType(state) {
 		});
 }
 
+export function changeReasonValidator(changeReason) {
+	return changeReason.trim().length > 0;
+}
+
 export function askChangeReason(state) {
 	return util
 		.prompt([
@@ -703,7 +707,7 @@ export function askChangeReason(state) {
 				message: `What is the reason for this change? ${chalk.red(
 					"(required)"
 				)}`,
-				validate: changeReason => changeReason.trim().length > 0
+				validate: changeReasonValidator
 			}
 		])
 		.then(({ changeReason }) => {
@@ -978,10 +982,11 @@ export function verifyUpstream(state) {
 
 export function verifyChangelog() {
 	util.log.begin("Verifying CHANGELOG.md");
-	util.log.end();
 	if (util.fileExists(CHANGELOG_PATH)) {
+		util.log.end();
 		return Promise.resolve();
 	}
+	util.log.end();
 
 	return util
 		.prompt([

--- a/src/workflows/steps/index.js
+++ b/src/workflows/steps/index.js
@@ -926,8 +926,8 @@ export function verifyRemotes(state) {
 	const command = `git remote`;
 	return util.exec(command).then(response => {
 		state.remotes = {
-			origin: response.includes("origin") ? true : false,
-			upstream: response.includes("upstream") ? true : false
+			origin: response.includes("origin"),
+			upstream: response.includes("upstream")
 		};
 	});
 }
@@ -968,9 +968,7 @@ export function verifyUpstream(state) {
 				const command = `git remote add upstream ${parent_ssh_url}`;
 				return util
 					.exec(command)
-					.then(() => {
-						util.log.end();
-					})
+					.then(util.log.end)
 					.catch(err => logger.log(chalk.red(err)));
 			})
 			.catch(err => logger.log(chalk.red(err)));


### PR DESCRIPTION
### Short description of the work completed

> Fixed varius issues. This includes:
>
> - Upgrading to use babel-present-env
> - Verifying remotes, package.json, and CHANGELOG.md on --reset ( more new repository friendly )
> - Made changeReason required when running --qa

Should resolve issues: https://github.com/LeanKit-Labs/tag-release/issues/66, https://github.com/LeanKit-Labs/tag-release/issues/90, and https://github.com/LeanKit-Labs/tag-release/issues/45

### Steps to test (if not obvious)

Friendlier to New Repositories
1. Make a new repo in GitHub
2. clone repo
3. run `tag-release --reset` and follow steps
4. Should see that it will error out if no package.json and suggest a way to fix that, should updated your remotes ( origin and upstream ), and prompt you to create a CHANGELOG.md if it didn't already exist

NOTE: When setting an upstream remote it will use the parent property to set it from the details returned by the GitHub API. If there is no parent property it will use the repository's ssh_url instead. In order to test both you will need to fork off of a "master" repo to see that it is correctly set.

--qa
1. run `tag-release --qa`
2. Should see that the changeReason is now required after selecting or bumping backages

### For Reviewer Use Only

- [x] Code Reviewed
- [x] Tests Passed
- [x] Coverage Reviewed
- [x] Feature worked as expected
- [x] Added or updated flags to `--help` and `README.md`
- [x] Is the version upgrade path clear for this change? (breaking vs minor vs
  patch)
- [x] Follow up work tracked in a card if needed
