### PR TITLE
No longer able to pre-release hosting projects

### DIFF
--- a/specs/workflows/pre-release.spec.js
+++ b/specs/workflows/pre-release.spec.js
@@ -4,6 +4,7 @@ import * as run from "../../src/workflows/steps";
 describe("pre-release workflow", () => {
 	it("should have all of the required steps", () => {
 		expect(preReleaseWorkflow).toEqual([
+			run.isPackagePrivate,
 			run.gitFetchUpstream,
 			run.getCurrentBranchVersion,
 			run.setPrereleaseIdentifier,

--- a/specs/workflows/steps/index.spec.js
+++ b/specs/workflows/steps/index.spec.js
@@ -3110,4 +3110,26 @@ describe("shared workflow steps", () => {
 			});
 		});
 	});
+
+	describe("isPackagePrivate", () => {
+		beforeEach(() => {
+			state.configPath = "./package.json";
+			util.advise = jest.fn(() => Promise.resolve());
+			util.isPackagePrivate = jest.fn(() => true);
+		});
+
+		it("should advise when package.json is set to private", () => {
+			return run.isPackagePrivate(state).then(() => {
+				expect(util.advise).toHaveBeenCalledTimes(1);
+				expect(util.advise).toHaveBeenCalledWith("privatePackage");
+			});
+		});
+
+		it("should resolve when package.json isn't private", () => {
+			util.isPackagePrivate = jest.fn(() => false);
+			return run.isPackagePrivate(state).then(() => {
+				expect(util.advise).toHaveBeenCalledTimes(0);
+			});
+		});
+	});
 });

--- a/src/advise.js
+++ b/src/advise.js
@@ -79,7 +79,11 @@ Either you don't have an upstream with the same name as your local, or we weren'
 
 You can use the 'npm init' command to generate a package.json for you.
 
-Alternatively, You can specifiy a different config file by using the -c command: 'tag-release -c another.json'`
+Alternatively, You can specifiy a different config file by using the -c command: 'tag-release -c another.json'`,
+
+	privatePackage: `It appears you are trying to pre-release a private repository. The pre-release flag is meant for dependency projects.
+
+Did you mean to run 'tag-release --qa' instead?`
 };
 
 const MAXIMUM_WIDTH = 50;

--- a/src/workflows/pre-release.js
+++ b/src/workflows/pre-release.js
@@ -1,6 +1,7 @@
 import * as run from "./steps/index";
 
 export default [
+	run.isPackagePrivate,
 	run.gitFetchUpstream,
 	run.getCurrentBranchVersion,
 	run.setPrereleaseIdentifier,

--- a/src/workflows/steps/index.js
+++ b/src/workflows/steps/index.js
@@ -1029,3 +1029,12 @@ export function verifyPackageJson(state) {
 
 	return Promise.resolve();
 }
+
+export function isPackagePrivate(state) {
+	const { configPath } = state;
+	if (util.isPackagePrivate(configPath)) {
+		util.advise("privatePackage");
+	}
+
+	return Promise.resolve();
+}


### PR DESCRIPTION
### Short description of the work completed

> Removed the ability to pre-release hosting projects.

### Steps to test (if not obvious)

1. Go into a hosting project repository. ( One with a private package.json )
2. Attempt to run `tag-release -p`
3. Should advise saying you can't do this.
4. Go into a dependency project repository. ( One with a non private package.json )

NOTES: This should resolve https://github.com/LeanKit-Labs/tag-release/issues/98

### For Reviewer Use Only

- [x] Code Reviewed
- [x] Tests Passed
- [x] Coverage Reviewed
- [x] Feature worked as expected
- [x] Added or updated flags to `--help` and `README.md`
- [x] Is the version upgrade path clear for this change? (breaking vs minor vs
  patch)
- [x] Follow up work tracked in a card if needed
