### PR TITLE
Added ability to have changes in hosting repository and bump versions.

### DIFF
--- a/specs/git.spec.js
+++ b/specs/git.spec.js
@@ -341,6 +341,12 @@ describe("git", () => {
 					args: `checkout -b feature-branch upstream/develop`
 				}
 			},
+			checkoutAndCreateBranchWithoutTracking: {
+				args: "feature-branch",
+				expectedRunCommandArgs: {
+					args: `checkout -b feature-branch`
+				}
+			},
 			status: {
 				expectedRunCommandArgs: { args: `status`, showOutput: true }
 			}

--- a/specs/workflows/qa.spec.js
+++ b/specs/workflows/qa.spec.js
@@ -19,7 +19,9 @@ describe("qa workflows", () => {
 		it("should have all of the required steps", () => {
 			expect(qaDefault).toEqual([
 				run.checkHasDevelopBranch,
-				run.gitCheckoutDevelop,
+				run.getCurrentBranchVersion,
+				run.checkNewCommits,
+				run.useCurrentBranchOrCheckoutDevelop,
 				run.gitRebaseUpstreamDevelop,
 				run.getPackageScope,
 				run.askReposToUpdate,
@@ -28,6 +30,7 @@ describe("qa workflows", () => {
 				run.askChangeReason,
 				run.githubUpstream,
 				run.askVersions,
+				run.promptKeepBranchOrCreateNew,
 				run.askChangeType,
 				run.promptBranchName,
 				run.gitCheckoutAndCreateBranch,

--- a/src/advise.js
+++ b/src/advise.js
@@ -80,10 +80,12 @@ Either you don't have an upstream with the same name as your local, or we weren'
 You can use the 'npm init' command to generate a package.json for you.
 
 Alternatively, You can specifiy a different config file by using the -c command: 'tag-release -c another.json'`,
-
 	privatePackage: `It appears you are trying to pre-release a private repository. The pre-release flag is meant for dependency projects.
 
-Did you mean to run 'tag-release --qa' instead?`
+Did you mean to run 'tag-release --qa' instead?`,
+	qaNoChangeNoDevelop: `It appears this repository doesn't have any new changes or a develop branch.
+
+Are you sure you need to run 'tag-release --qa'?`
 };
 
 const MAXIMUM_WIDTH = 50;

--- a/src/git.js
+++ b/src/git.js
@@ -359,6 +359,11 @@ const git = {
 		return git.runCommand({ args });
 	},
 
+	checkoutAndCreateBranchWithoutTracking(branch) {
+		const args = `checkout -b ${branch}`;
+		return git.runCommand({ args });
+	},
+
 	rebaseUpstreamBranch({ branch, onError }) {
 		return git.rebase({ branch: `upstream/${branch}`, onError });
 	},

--- a/src/workflows/qa.js
+++ b/src/workflows/qa.js
@@ -8,7 +8,9 @@ export default [
 
 export const qaDefault = [
 	run.checkHasDevelopBranch,
-	run.gitCheckoutDevelop,
+	run.getCurrentBranchVersion,
+	run.checkNewCommits,
+	run.useCurrentBranchOrCheckoutDevelop,
 	run.gitRebaseUpstreamDevelop,
 	run.getPackageScope,
 	run.askReposToUpdate,
@@ -17,6 +19,7 @@ export const qaDefault = [
 	run.askChangeReason,
 	run.githubUpstream,
 	run.askVersions,
+	run.promptKeepBranchOrCreateNew,
 	run.askChangeType,
 	run.promptBranchName,
 	run.gitCheckoutAndCreateBranch,


### PR DESCRIPTION
### Short description of the work completed

> Can now have changes in a hosting repository branch and run `tag-release --qa` and it will keep those changes as well as allowing you to bump versions.

### Steps to test (if not obvious)

1. Go into develop/master and run `tag-release --qa`
2. Should work as before.
3. Go into a branch in a hosting project that has changes and run `tag-release --qa`
4. Should now create a branch based on that branch to keep your changes and allow for the bumping of packages as before.
5. Go into a repository that doesn't have a develop branch and checkout a branch with no new changes and run `tag-release --qa`.
6. Should error out and advise the user.

### For Reviewer Use Only

- [x] Code Reviewed
- [x] Tests Passed
- [x] Coverage Reviewed
- [x] Feature worked as expected
- [x] Added or updated flags to `--help` and `README.md`
- [x] Is the version upgrade path clear for this change? (breaking vs minor vs
  patch)
- [x] Follow up work tracked in a card if needed
