### PR TITLE
Auto bump with existing pre-release identifier

### DIFF
--- a/specs/workflows/pre-release.spec.js
+++ b/specs/workflows/pre-release.spec.js
@@ -7,6 +7,7 @@ describe("pre-release workflow", () => {
 			run.isPackagePrivate,
 			run.gitFetchUpstream,
 			run.getCurrentBranchVersion,
+			run.checkExistingPrereleaseIdentifier,
 			run.setPrereleaseIdentifier,
 			run.getFeatureBranch,
 			run.gitMergeUpstreamBranch,

--- a/specs/workflows/steps/index.spec.js
+++ b/specs/workflows/steps/index.spec.js
@@ -182,6 +182,40 @@ describe("shared workflow steps", () => {
 		});
 	});
 
+	describe("checkExistingPrereleaseIdentifier", () => {
+		beforeEach(() => {
+			state = {};
+		});
+
+		it("should not modify state with existing identifier", () => {
+			state.identifier = "some-identifier";
+			state.currentVersion = "1.0.0-some-other-identifier.0";
+			return run.checkExistingPrereleaseIdentifier(state).then(() => {
+				expect(state).toHaveProperty("identifier");
+				expect(state.identifier).toEqual("some-identifier");
+				expect(state).not.toHaveProperty("release");
+			});
+		});
+
+		it("should set state with identifier and release type", () => {
+			state.currentVersion = "1.0.0-some-other-identifier.0";
+			return run.checkExistingPrereleaseIdentifier(state).then(() => {
+				expect(state).toHaveProperty("identifier");
+				expect(state.identifier).toEqual("some-other-identifier");
+				expect(state).toHaveProperty("release");
+				expect(state.release).toEqual("prerelease");
+			});
+		});
+
+		it("should do nothing with no existing identifier", () => {
+			state.currentVersion = "1.0.0";
+			return run.checkExistingPrereleaseIdentifier(state).then(() => {
+				expect(state).not.toHaveProperty("identifier");
+				expect(state).not.toHaveProperty("release");
+			});
+		});
+	});
+
 	describe("setPrereleaseIdentifier", () => {
 		beforeEach(() => {
 			util.prompt = jest.fn(() =>

--- a/src/workflows/pre-release.js
+++ b/src/workflows/pre-release.js
@@ -4,6 +4,7 @@ export default [
 	run.isPackagePrivate,
 	run.gitFetchUpstream,
 	run.getCurrentBranchVersion,
+	run.checkExistingPrereleaseIdentifier,
 	run.setPrereleaseIdentifier,
 	run.getFeatureBranch,
 	run.gitMergeUpstreamBranch,

--- a/src/workflows/steps/index.js
+++ b/src/workflows/steps/index.js
@@ -53,6 +53,24 @@ export function checkHasDevelopBranch(state) {
 		});
 }
 
+export function checkExistingPrereleaseIdentifier(state) {
+	const { identifier, currentVersion } = state;
+
+	if (identifier && identifier.length) {
+		return Promise.resolve();
+	}
+
+	const preReleaseRegEx = /^v?\d+\.\d+\.\d+-(.+)\.\d+$/;
+	const [, id] = preReleaseRegEx.exec(currentVersion) || [];
+
+	if (id) {
+		state.identifier = id;
+		state.release = "prerelease";
+	}
+
+	return Promise.resolve();
+}
+
 export function setPrereleaseIdentifier(state) {
 	const { identifier } = state;
 


### PR DESCRIPTION
### Short description of the work completed

> When bumping existing pre-release `tag-release` should no longer prompt for identifier, nor should it ask what type you are bumping.

### Steps to test (if not obvious)

1. Elijah knows the way. =)

### For Reviewer Use Only

- [x] Code Reviewed
- [x] Tests Passed
- [x] Coverage Reviewed
- [x] Feature worked as expected
- [x] Added or updated flags to `--help` and `README.md`
- [x] Is the version upgrade path clear for this change? (breaking vs minor vs
  patch)
- [x] Follow up work tracked in a card if needed
