### PR TITLE
Fixed --qa not merging with upstream branch when exists

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-release",
-  "version": "5.13.0",
+  "version": "5.14.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/specs/git.spec.js
+++ b/specs/git.spec.js
@@ -388,6 +388,13 @@ describe("git", () => {
 					logMessage: "",
 					onError: {}
 				}
+			},
+			branchExistsUpstream: {
+				args: "feature-branch",
+				expectedRunCommandArgs: {
+					args: `ls-remote upstream feature-branch`,
+					logMessage: `Checking if "feature-branch" exists on upstream`
+				}
 			}
 		};
 

--- a/src/git.js
+++ b/src/git.js
@@ -254,6 +254,19 @@ const git = {
 			});
 	},
 
+	branchExistsUpstream(branch) {
+		const args = `ls-remote upstream ${branch}`;
+		return git
+			.runCommand({
+				args,
+				logMessage: `Checking if "${branch}" exists on upstream`
+			})
+			.then(result => {
+				const branches = result.split("\n").filter(String);
+				return Promise.resolve(!!branches.length);
+			});
+	},
+
 	createLocalBranch(branch, tracking = branch) {
 		const args = `branch ${branch} upstream/${tracking}`;
 		return git.runCommand({

--- a/src/workflows/steps/index.js
+++ b/src/workflows/steps/index.js
@@ -1152,7 +1152,7 @@ export function useCurrentBranchOrCheckoutDevelop(state) {
 }
 
 export function promptKeepBranchOrCreateNew(state) {
-	const { log } = state;
+	const { log, branch } = state;
 
 	if (!log.length) {
 		return Promise.resolve();
@@ -1169,7 +1169,11 @@ export function promptKeepBranchOrCreateNew(state) {
 		])
 		.then(answers => {
 			state.keepBranch = answers.keep;
-			return Promise.resolve();
+			return git.branchExistsUpstream(branch).then(exists => {
+				if (exists) {
+					return git.merge(`upstream/${branch}`, true);
+				}
+			});
 		});
 }
 
@@ -1271,7 +1275,7 @@ export function getDependenciesFromFile(state) {
 	state.dependencies = content ? content : {};
 
 	return Promise.resolve();
-};
+}
 
 export function updatePackageLockJson(state) {
 	if (!util.fileExists(PACKAGELOCKJSON_PATH)) {


### PR DESCRIPTION
### Short description of the work completed

> If an upstream version exists of the branch you are qaing it needs to get the latest from upstream to make sure your local branch is up to date before you try to bump.

### Steps to test (if not obvious)

1. Run --qa in all the ways!

### For Reviewer Use Only

- [x] Code Reviewed
- [x] Tests Passed
- [x] Coverage Reviewed
- [x] Feature worked as expected
- [x] Added or updated flags to `--help` and `README.md`
- [x] Is the version upgrade path clear for this change? (breaking vs minor vs
  patch)
- [x] Follow up work tracked in a card if needed
