### PR TITLE
Fixed error when dependencies didn't exist during default tag-release flow

### DIFF
--- a/specs/workflows/steps/index.spec.js
+++ b/specs/workflows/steps/index.spec.js
@@ -3666,6 +3666,13 @@ feature-last-branch`)
 			});
 		});
 
+		it("should do nothing if depedencies don't exist", () => {
+			state.dependencies = undefined;
+			return run.updatePackageLockJson(state).then(() => {
+				expect(sequence).toHaveBeenCalledTimes(0);
+			});
+		});
+
 		it("should call 'sequence' with an array of dependencies", () => {
 			return run.updatePackageLockJson(state).then(() => {
 				expect(sequence).toHaveBeenCalledTimes(1);
@@ -3805,7 +3812,7 @@ feature-last-branch`)
 			util.readJSONFile = jest.fn(() => "");
 			return run.getDependenciesFromFile(state).then(() => {
 				expect(state).toHaveProperty("dependencies");
-				expect(state.dependencies).toEqual({});
+				expect(state.dependencies).toEqual([]);
 			});
 		});
 	});

--- a/src/workflows/steps/index.js
+++ b/src/workflows/steps/index.js
@@ -1272,17 +1272,18 @@ export function getDependenciesFromFile(state) {
 		path.join(__dirname, ".dependencies.json")
 	);
 
-	state.dependencies = content ? content : {};
+	state.dependencies = content ? content : [];
 
 	return Promise.resolve();
 }
 
 export function updatePackageLockJson(state) {
-	if (!util.fileExists(PACKAGELOCKJSON_PATH)) {
+	const { dependencies, scope } = state;
+
+	if (!util.fileExists(PACKAGELOCKJSON_PATH) || !dependencies) {
 		return Promise.resolve();
 	}
 
-	const { dependencies, scope } = state;
 	const installs = dependencies.map(dep =>
 		npmInstallPackage(`${scope}/${dep.pkg}@${dep.version}`)
 	);


### PR DESCRIPTION
### For Reviewer Use Only

- [x] Code Reviewed
- [x] Tests Passed
- [x] Coverage Reviewed
- [x] Feature worked as expected
- [x] Added or updated flags to `--help` and `README.md`
- [x] Is the version upgrade path clear for this change? (breaking vs minor vs
  patch)
- [x] Follow up work tracked in a card if needed
