### PR TITLE
Added pushing specific tags to remote instead of all tags

### DIFF
--- a/specs/git.spec.js
+++ b/specs/git.spec.js
@@ -276,28 +276,26 @@ describe("git", () => {
 			push: {
 				args: { branch: "feature-branch", remote: "upstream" },
 				expectedRunCommandArgs: {
-					args: "push -u upstream feature-branch --tags"
+					args: "push upstream feature-branch"
 				}
 			},
 			pushUpstreamMaster: {
 				expectedRunCommandArgs: {
-					args: "push -u upstream master",
+					args: "push upstream master",
 					failHelpKey: "gitPushUpstreamFeatureBranch"
 				}
 			},
-			pushUpstreamMasterWithTags: {
+			pushUpstreamMasterWithTag: {
+				args: { tag: "v1.0.0" },
 				expectedRunCommandArgs: {
-					args: "push -u upstream master --tags"
+					args: "push upstream master refs/tags/v1.0.0"
 				}
 			},
 			pushOriginMaster: {
-				expectedRunCommandArgs: { args: "push -u origin master" }
-			},
-			pushOriginMasterWithTags: {
-				expectedRunCommandArgs: { args: "push -u origin master --tags" }
+				expectedRunCommandArgs: { args: "push origin master" }
 			},
 			pushUpstreamDevelop: {
-				expectedRunCommandArgs: { args: "push -u upstream develop" }
+				expectedRunCommandArgs: { args: "push upstream develop" }
 			},
 			uncommittedChangesExist: {
 				expectedRunCommandArgs: {
@@ -429,10 +427,9 @@ describe("git", () => {
 				}
 			},
 			deleteBranchUpstream: {
-				args: "feature-branch",
+				args: { branch: "feature-branch" },
 				expectedRunCommandArgs: {
 					args: `push upstream :feature-branch`,
-					showOutput: true,
 					logMessage: "",
 					onError: {}
 				}
@@ -447,7 +444,7 @@ describe("git", () => {
 			createRemoteBranch: {
 				args: { branch: "feature-branch" },
 				expectedRunCommandArgs: {
-					args: `push upstream master:feature-branch`
+					args: `push -u upstream master:feature-branch`
 				}
 			},
 			getLastCommitText: {
@@ -460,8 +457,7 @@ describe("git", () => {
 			pushRemoteBranch: {
 				args: { branch: "feature-branch" },
 				expectedRunCommandArgs: {
-					args: `push -u origin feature-branch`,
-					onError: {}
+					args: `push -u origin feature-branch`
 				}
 			}
 		};
@@ -538,13 +534,12 @@ describe("git", () => {
 				return git
 					.push({
 						branch: "feature-branch",
-						remote: "upstream",
-						includeTags: false
+						remote: "upstream"
 					})
 					.then(() => {
 						expect(git.runCommand).toHaveBeenCalledTimes(1);
 						expect(git.runCommand).toHaveBeenCalledWith({
-							args: "push -u upstream feature-branch"
+							args: "push upstream feature-branch"
 						});
 					});
 			});
@@ -656,7 +651,7 @@ describe("git", () => {
 						.then(() => {
 							expect(git.runCommand).toHaveBeenCalledTimes(1);
 							expect(git.runCommand).toHaveBeenCalledWith({
-								args: "push upstream develop:feature-branch"
+								args: "push -u upstream develop:feature-branch"
 							});
 						});
 				});
@@ -670,7 +665,7 @@ describe("git", () => {
 						.then(() => {
 							expect(git.runCommand).toHaveBeenCalledTimes(1);
 							expect(git.runCommand).toHaveBeenCalledWith({
-								args: "push origin master:feature-branch"
+								args: "push -u origin master:feature-branch"
 							});
 						});
 				});
@@ -686,7 +681,7 @@ describe("git", () => {
 							expect(git.runCommand).toHaveBeenCalledTimes(1);
 							expect(git.runCommand).toHaveBeenCalledWith({
 								args:
-									"push origin feature-branch:feature-branch"
+									"push -u origin feature-branch:feature-branch"
 							});
 						});
 				});

--- a/specs/workflows/steps/index.spec.js
+++ b/specs/workflows/steps/index.spec.js
@@ -1085,10 +1085,10 @@ describe("shared workflow steps", () => {
 	});
 
 	describe("gitPushUpstreamMaster", () => {
-		it("should call `git.pushUpstreamMasterWithTags`", () => {
-			git.pushUpstreamMasterWithTags = jest.fn(() => Promise.resolve());
+		it("should call `git.pushUpstreamMasterWithTag`", () => {
+			git.pushUpstreamMasterWithTag = jest.fn(() => Promise.resolve());
 			return run.gitPushUpstreamMaster(state).then(() => {
-				expect(git.pushUpstreamMasterWithTags).toHaveBeenCalledTimes(1);
+				expect(git.pushUpstreamMasterWithTag).toHaveBeenCalledTimes(1);
 			});
 		});
 	});
@@ -1257,12 +1257,14 @@ describe("shared workflow steps", () => {
 		});
 
 		it("should call `git.push` with the appropriate options", () => {
-			state = { branch: "feature-branch" };
+			state = { branch: "feature-branch", tag: "v1.0.0" };
 			return run.gitPushUpstreamFeatureBranch(state).then(() => {
 				expect(git.push).toHaveBeenCalledTimes(1);
 				expect(git.push).toHaveBeenCalledWith({
-					branch: "feature-branch",
-					remote: "upstream"
+					branch: state.branch,
+					remote: "upstream",
+					option: "-u",
+					tag: state.tag
 				});
 			});
 		});
@@ -1283,8 +1285,9 @@ describe("shared workflow steps", () => {
 			return run.gitForcePushUpstreamFeatureBranch(state).then(() => {
 				expect(git.push).toHaveBeenCalledTimes(1);
 				expect(git.push).toHaveBeenCalledWith({
-					branch: "-f feature-branch",
-					remote: "upstream"
+					branch: state.branch,
+					remote: "upstream",
+					option: "-f"
 				});
 			});
 		});
@@ -4042,8 +4045,8 @@ feature-last-branch`)
 		});
 
 		it("should resolve when deleteBranch fails", () => {
-			git.deleteBranchUpstream = jest.fn((...args) => {
-				return args[3]()();
+			git.deleteBranchUpstream = jest.fn(args => {
+				return args.onError()();
 			});
 			return run.deleteUpstreamFeatureBranch(state).then(() => {
 				expect(util.advise).toHaveBeenCalledTimes(0);

--- a/src/git.js
+++ b/src/git.js
@@ -207,12 +207,23 @@ const git = {
 		return git.runCommand({ args });
 	},
 
-	push({ branch, remote, includeTags = true, failHelpKey }) {
-		const args = `push -u ${remote} ${branch}${
-			includeTags ? " --tags" : ""
-		}`;
+	push({
+		branch,
+		remote,
+		base,
+		option,
+		tag,
+		logMessage,
+		failHelpKey,
+		onError
+	}) {
+		const args = `push ${option ? `${option} ` : ""}${remote} ${
+			base ? `${base}:${branch}` : `${branch}`
+		}${tag ? ` refs/tags/${tag}` : ""}`;
 		return git.runCommand(
-			failHelpKey && failHelpKey.length ? { args, failHelpKey } : { args }
+			failHelpKey && failHelpKey.length
+				? { args, failHelpKey, logMessage, onError }
+				: { args, logMessage, onError }
 		);
 	},
 
@@ -220,40 +231,29 @@ const git = {
 		return git.push({
 			branch: "master",
 			remote: "upstream",
-			includeTags: false,
 			failHelpKey: "gitPushUpstreamFeatureBranch"
 		});
 	},
 
-	pushUpstreamMasterWithTags() {
+	pushUpstreamMasterWithTag({ tag }) {
 		return git.push({
 			branch: "master",
 			remote: "upstream",
-			includeTags: true
+			tag
 		});
 	},
 
 	pushOriginMaster() {
 		return git.push({
 			branch: "master",
-			remote: "origin",
-			includeTags: false
-		});
-	},
-
-	pushOriginMasterWithTags() {
-		return git.push({
-			branch: "master",
-			remote: "origin",
-			includeTags: true
+			remote: "origin"
 		});
 	},
 
 	pushUpstreamDevelop() {
 		return git.push({
 			branch: "develop",
-			remote: "upstream",
-			includeTags: false
+			remote: "upstream"
 		});
 	},
 
@@ -392,14 +392,13 @@ const git = {
 		return git.runCommand({ args, showOutput, logMessage, onError });
 	},
 
-	deleteBranchUpstream(
-		branch,
-		showOutput = true,
-		logMessage = "",
-		onError = {}
-	) {
-		const args = `push upstream :${branch}`;
-		return git.runCommand({ args, showOutput, logMessage, onError });
+	deleteBranchUpstream({ branch, logMessage = "", onError = {} }) {
+		return git.push({
+			branch: `:${branch}`,
+			remote: "upstream",
+			logMessage,
+			onError
+		});
 	},
 
 	stageFiles() {
@@ -463,13 +462,21 @@ const git = {
 	},
 
 	createRemoteBranch({ branch, remote = "upstream", base = "master" }) {
-		const args = `push ${remote} ${base}:${branch}`;
-		return git.runCommand({ args });
+		return git.push({
+			branch,
+			option: "-u",
+			base,
+			remote
+		});
 	},
 
-	pushRemoteBranch({ branch, remote = "origin", onError = {} }) {
-		const args = `push -u ${remote} ${branch}`;
-		return git.runCommand({ args, onError });
+	pushRemoteBranch({ branch, remote = "origin", onError }) {
+		return git.push({
+			branch,
+			option: "-u",
+			remote,
+			onError
+		});
 	},
 
 	getLastCommitText(showOutput = false) {

--- a/src/workflows/steps/index.js
+++ b/src/workflows/steps/index.js
@@ -379,10 +379,12 @@ ${chalk.green(log)}`);
 		const { versions: { newVersion } } = state;
 		const tag = `v${newVersion}`;
 
-		return git.tag(tag, tag);
+		return git.tag(tag, tag).then(() => {
+			state.tag = tag;
+		});
 	},
-	gitPushUpstreamMaster() {
-		return git.pushUpstreamMasterWithTags();
+	gitPushUpstreamMaster({ tag }) {
+		return git.pushUpstreamMasterWithTag({ tag });
 	},
 	npmPublish(state) {
 		const { configPath, prerelease } = state;
@@ -444,18 +446,23 @@ ${chalk.green(log)}`);
 			return git.pushUpstreamDevelop();
 		}
 	},
-	gitPushUpstreamFeatureBranch(state) {
-		const { branch } = state;
-
+	gitPushUpstreamFeatureBranch({ branch, tag }) {
 		if (branch && branch.length) {
-			return git.push({ branch, remote: "upstream" });
+			return git.push({
+				branch,
+				remote: "upstream",
+				option: "-u",
+				tag
+			});
 		}
 	},
-	gitForcePushUpstreamFeatureBranch(state) {
-		const { branch } = state;
-
+	gitForcePushUpstreamFeatureBranch({ branch }) {
 		if (branch && branch.length) {
-			return git.push({ branch: `-f ${branch}`, remote: "upstream" });
+			return git.push({
+				branch,
+				remote: "upstream",
+				option: "-f"
+			});
 		}
 	},
 	gitPushOriginMaster() {
@@ -1273,12 +1280,11 @@ ${chalk.green(log)}`);
 			return () => Promise.resolve();
 		};
 
-		return git.deleteBranchUpstream(
+		return git.deleteBranchUpstream({
 			branch,
-			true,
-			"Cleaning upstream feature branch",
+			logMessage: "Cleaning upstream feature branch",
 			onError
-		);
+		});
 	},
 	saveDependencies(state) {
 		const { dependencies, changeReason } = state;


### PR DESCRIPTION
### Short description of the work completed

> Previously, `tag-release` would do a `--tags` on its push to the upstream causing all tags to be pushed. Including bad tags... This creates quite a headache when trying to clean it up. This work now only pushes the specific tag that the run of `tag-release` is worried with.

### Steps to test (if not obvious)

1. Test all the flows!

### For Reviewer Use Only

- [x] Code Reviewed
- [x] Tests Passed
- [x] Coverage Reviewed
- [x] Feature worked as expected
- [x] Updated `src/help.js` and `README.md`
- [x] Is the version upgrade path clear for this change? (breaking vs minor vs
  patch)
- [x] Follow up work tracked in a card if needed