### PR TITLE
Added the ability to reset to branch if stashed. Fixed qa issue with no pre-releases

### DIFF
--- a/specs/git.spec.js
+++ b/specs/git.spec.js
@@ -542,8 +542,17 @@ describe("git", () => {
 	});
 
 	describe("stash", () => {
+		it("should call stash", () => {
+			git.stash({});
+			expect(runCommand).toHaveBeenCalledTimes(1);
+			expect(runCommand).toHaveBeenCalledWith({
+				args: "stash",
+				logMessage: "stashing uncommitted changes"
+			});
+		});
+
 		it("should call stash with appropriate args", () => {
-			git.stash();
+			git.stash({ option: "--include-untracked" });
 			expect(runCommand).toHaveBeenCalledTimes(1);
 			expect(runCommand).toHaveBeenCalledWith({
 				args: "stash --include-untracked",

--- a/specs/workflows/l10n.spec.js
+++ b/specs/workflows/l10n.spec.js
@@ -23,7 +23,8 @@ describe("l10n workflow", () => {
 			run.createOrCheckoutBranch,
 			run.gitMergeUpstreamBranch,
 			run.diffWithUpstreamMaster,
-			run.commitDiffWithUpstreamMaster
+			run.commitDiffWithUpstreamMaster,
+			run.resetIfStashed
 		]);
 	});
 });

--- a/specs/workflows/qa-automated.spec.js
+++ b/specs/workflows/qa-automated.spec.js
@@ -5,6 +5,7 @@ describe("qa-automated workflow", () => {
 	it("should have all of the required steps", () => {
 		expect(qaAuto).toEqual([
 			run.changeDirectory,
+			run.stashChanges,
 			run.checkoutl10nBranch,
 			run.getCurrentBranchVersion,
 			run.checkNewCommits,
@@ -13,7 +14,8 @@ describe("qa-automated workflow", () => {
 			run.updateDependencies,
 			run.gitAdd,
 			run.gitCommitBumpMessage,
-			run.gitPushUpstreamFeatureBranch
+			run.gitPushUpstreamFeatureBranch,
+			run.resetIfStashed
 		]);
 	});
 });

--- a/specs/workflows/steps/index.spec.js
+++ b/specs/workflows/steps/index.spec.js
@@ -1777,6 +1777,53 @@ describe("shared workflow steps", () => {
 		});
 	});
 
+	describe("resetIfStashed", () => {
+		describe("when stashed", () => {
+			beforeEach(() => {
+				command.checkoutBranch = jest.fn(() => Promise.resolve());
+				state.stashed = "feature-branch";
+				run.resetIfStashed(state);
+			});
+
+			it("should set step on state", () => {
+				expect(state).toHaveProperty("step");
+				expect(state.step).toEqual("resetIfStashed");
+			});
+
+			it("it should checkout branch with stashed changes on it", () => {
+				expect(command.checkoutBranch).toHaveBeenCalledTimes(1);
+				expect(command.checkoutBranch).toHaveBeenCalledWith({
+					branch: "feature-branch",
+					spinner: undefined,
+					repo: undefined
+				});
+			});
+
+			it("it should call git.stash", () => {
+				expect(git.stash).toHaveBeenCalledTimes(1);
+				expect(git.stash).toHaveBeenCalledWith({
+					option: "pop"
+				});
+			});
+		});
+
+		describe("when not stashed", () => {
+			beforeEach(() => {
+				command.checkoutBranch = jest.fn(() => Promise.resolve());
+				run.resetIfStashed(state);
+			});
+
+			it("should set step on state", () => {
+				expect(state).toHaveProperty("step");
+				expect(state.step).toEqual("resetIfStashed");
+			});
+
+			it("should not call git.stash", () => {
+				expect(git.stash).toHaveBeenCalledTimes(0);
+			});
+		});
+	});
+
 	describe("verifyMasterBranch", () => {
 		beforeEach(() => {
 			command.branchExists = jest.fn(() => Promise.resolve(true));

--- a/src/git.js
+++ b/src/git.js
@@ -172,8 +172,8 @@ const git = {
 		return runCommand({ args });
 	},
 
-	stash() {
-		const args = "stash --include-untracked";
+	stash({ option }) {
+		const args = `stash${option ? ` ${option}` : ""}`;
 		return runCommand({
 			args,
 			logMessage: "stashing uncommitted changes"

--- a/src/workflows/l10n.js
+++ b/src/workflows/l10n.js
@@ -18,6 +18,7 @@ module.exports = {
 		run.createOrCheckoutBranch,
 		run.gitMergeUpstreamBranch,
 		run.diffWithUpstreamMaster,
-		run.commitDiffWithUpstreamMaster
+		run.commitDiffWithUpstreamMaster,
+		run.resetIfStashed
 	]
 };

--- a/src/workflows/qa-automated.js
+++ b/src/workflows/qa-automated.js
@@ -12,6 +12,7 @@ const run = require("./steps/index");
 
 module.exports = [
 	run.changeDirectory,
+	run.stashChanges,
 	run.checkoutl10nBranch,
 	run.getCurrentBranchVersion,
 	run.checkNewCommits,
@@ -20,5 +21,6 @@ module.exports = [
 	run.updateDependencies,
 	run.gitAdd,
 	run.gitCommitBumpMessage,
-	run.gitPushUpstreamFeatureBranch
+	run.gitPushUpstreamFeatureBranch,
+	run.resetIfStashed
 ];


### PR DESCRIPTION
### Short description of the work completed

> tag-release l10n (--check) will now reset you to your previous branch if you had unstashed changes there. Also, there was an issue when the host project wanted to QA bump but there weren't any pre-releases to add to the bump so it would go 💥 .

### Steps to test (if not obvious)

1. run `tag-release l10n --check` and `tag-release l10n`
2. can setup your env for dev or locale changes, as well as, make some local unstashed changes

### For Reviewer Use Only

- [x] Code Reviewed
- [x] Tests Passed
- [x] Coverage Reviewed
- [x] Feature worked as expected
- [x] Updated `src/help.js` and `README.md`
- [x] Is the version upgrade path clear for this change? (breaking vs minor vs
  patch)
- [x] Follow up work tracked in a card if needed
