### PR TITLE
add link to github on npm page

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "bin": {
     "tag-release": "./bin/tag-release.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LeanKit-Labs/tag-release"
+  },
   "scripts": {
     "lint": "eslint --fix --ignore-path .gitignore ./",
     "test": "jest --coverage",


### PR DESCRIPTION
### Short description of the work completed

> I added a link to GitHub so people viewing this package could more easily find the source code.

### Steps to test (if not obvious)

1. Frankly, I'm unsure how to test that this will show up on the npm page (https://www.npmjs.com/package/tag-release) without merging this branch.

Steps to test (if not obvious)
Frankly, I'm unsure how to test that this will show up on the npm page (https://www.npmjs.com/package/tag-release) without merging this branch.
### For Reviewer Use Only

- [ ] Code Reviewed
- [ ] Tests Passed
- [ ] Coverage Reviewed
- [ ] Feature worked as expected
- [ ] Updated `src/help.js` and `README.md`
- [ ] Is the version upgrade path clear for this change? (breaking vs minor vs
  patch)
- [ ] Follow up work tracked in a card if needed
