### PR TITLE
Added initial default tag version

### DIFF
--- a/specs/workflows/steps/index.spec.js
+++ b/specs/workflows/steps/index.spec.js
@@ -648,6 +648,42 @@ describe("shared workflow steps", () => {
 			});
 		});
 
+		describe("when there are no tagged releases in the upstream", () => {
+			beforeEach(() => {
+				command.getTagList = jest.fn(() => Promise.resolve([]));
+			});
+
+			it("should use default version", () => {
+				return run.askSemverJump(state).then(() => {
+					expect(util.prompt).toHaveBeenCalledTimes(1);
+					expect(util.prompt).toHaveBeenCalledWith([
+						{
+							type: "list",
+							name: "release",
+							message: "What type of release is this?",
+							choices: [
+								{
+									name: "Major (Breaking Change) v1.0.0",
+									value: "major",
+									short: "l"
+								},
+								{
+									name: "Minor (New Feature) v0.1.0",
+									value: "minor",
+									short: "m"
+								},
+								{
+									name: "Patch (Bug Fix) v0.0.1",
+									value: "patch",
+									short: "s"
+								}
+							]
+						}
+					]);
+				});
+			});
+		});
+
 		describe("when the release option has been provided", () => {
 			it("should not prompt the user to select a release option", () => {
 				state = {


### PR DESCRIPTION
### Short description of the work completed

> If there are no tagged releases on the upstream it will default the current version to 0.0.0 so you can create initial releases.

### Steps to test (if not obvious)

1. Make a new repo.
2. Make a change.
3. Push change to upstream
3. Run `tag-release` and you should see it default the version.

### For Reviewer Use Only

- [x] Code Reviewed
- [x] Tests Passed
- [x] Coverage Reviewed
- [x] Feature worked as expected
- [x] Updated `src/help.js` and `README.md`
- [x] Is the version upgrade path clear for this change? (breaking vs minor vs
  patch)
- [x] Follow up work tracked in a card if needed