### PR TITLE
Don't allow use to keep branch if on develop, master, or main branch

### DIFF
--- a/specs/workflows/steps/index.spec.js
+++ b/specs/workflows/steps/index.spec.js
@@ -3940,8 +3940,29 @@ describe("shared workflow steps", () => {
 			util.prompt = jest.fn(() => Promise.resolve({ keep: true }));
 		});
 
-		it("should resolve with no new commits", () => {
+		it("should resolve with no prompt if no new commits", () => {
 			state.log = "";
+			return run.promptKeepBranchOrCreateNew(state).then(() => {
+				expect(util.prompt).toHaveBeenCalledTimes(0);
+			});
+		});
+
+		it("should resolve with no prompt if on develop branch", () => {
+			state.branch = "develop";
+			return run.promptKeepBranchOrCreateNew(state).then(() => {
+				expect(util.prompt).toHaveBeenCalledTimes(0);
+			});
+		});
+
+		it("should resolve with no prompt if on master branch", () => {
+			state.branch = "master";
+			return run.promptKeepBranchOrCreateNew(state).then(() => {
+				expect(util.prompt).toHaveBeenCalledTimes(0);
+			});
+		});
+
+		it("should resolve with no prompt if on main branch", () => {
+			state.branch = "main";
 			return run.promptKeepBranchOrCreateNew(state).then(() => {
 				expect(util.prompt).toHaveBeenCalledTimes(0);
 			});

--- a/src/workflows/steps/index.js
+++ b/src/workflows/steps/index.js
@@ -15,6 +15,7 @@ const getContentsFromYAML = require("../../helpers/getContentsFromYAML");
 const getRootDirectory = require("../../helpers/getRootDirectory");
 
 const MAX_PERCENT = 100;
+const LOCKED_BRANCHES = ["develop", "master", "main"];
 
 const api = {
 	checkoutWorkingBranch(state) {
@@ -1373,7 +1374,7 @@ ${chalk.green(log)}`);
 		state.step = "promptKeepBranchOrCreateNew";
 		const { log, branch } = state;
 
-		if (!log.length) {
+		if (!log.length || LOCKED_BRANCHES.includes(branch)) {
 			return Promise.resolve();
 		}
 


### PR DESCRIPTION
### Short description of the work completed

> Prevent user from being able to keep branch on the develop, main, or master branch when running `qa`.

### Steps to test (if not obvious)

1. Have changes in develop that haven't been released.
2. run `tag-release qa` from develop, main, or master
3. should no longer allow you to keep using develop, main, or master as your branch to complete `qa` on

### For Reviewer Use Only

- [x] Code Reviewed
- [x] Tests Passed
- [x] Coverage Reviewed
- [x] Feature worked as expected
- [x] Updated `src/help.js` and `README.md`
- [x] Is the version upgrade path clear for this change? (breaking vs minor vs
  patch)
- [x] Follow up work tracked in a card if needed
