### PR TITLE
Reduced LK Id questions into one

### DIFF
--- a/specs/workflows/steps/index.spec.js
+++ b/specs/workflows/steps/index.spec.js
@@ -4616,30 +4616,18 @@ feature-last-branch`)
 		describe("when user has LK id", () => {
 			beforeEach(() => {
 				util.prompt = jest.fn(() =>
-					Promise.resolve({ hasId: true, id: "123456789" })
+					Promise.resolve({ id: "123456789" })
 				);
 			});
 
-			it("should prompt the user if they have a LK id", () => {
-				return run.addLKId(state).then(() => {
-					expect(util.prompt).toHaveBeenCalledWith([
-						{
-							type: "confirm",
-							name: "hasId",
-							message: "Do you have a LK ID?",
-							default: false
-						}
-					]);
-				});
-			});
-
-			it("should prompt the user for their LK id", () => {
+			it("should prompt the user for their LeanKit card id", () => {
 				return run.addLKId(state).then(() => {
 					expect(util.prompt).toHaveBeenCalledWith([
 						{
 							type: "input",
 							name: "id",
-							message: "What is your LK ID?"
+							message:
+								"What is the LeanKit card id? (leave empty to skip)"
 						}
 					]);
 				});
@@ -4655,17 +4643,23 @@ feature-last-branch`)
 
 		describe("when user doesn't have LK id", () => {
 			it("should prompt the user for their LK id", () => {
-				util.prompt = jest.fn(() => Promise.resolve({ hasId: false }));
+				util.prompt = jest.fn(() => Promise.resolve({ id: "" }));
 				return run.addLKId(state).then(() => {
-					expect(util.prompt).toHaveBeenCalledTimes(1);
 					expect(util.prompt).toHaveBeenCalledWith([
 						{
-							type: "confirm",
-							name: "hasId",
-							message: "Do you have a LK ID?",
-							default: false
+							type: "input",
+							name: "id",
+							message:
+								"What is the LeanKit card id? (leave empty to skip)"
 						}
 					]);
+				});
+			});
+
+			it("should persist default LK id to the workflow state", () => {
+				return run.addLKId(state).then(() => {
+					expect(state).toHaveProperty("lkId");
+					expect(state.lkId).toEqual("");
 				});
 			});
 		});

--- a/src/workflows/steps/index.js
+++ b/src/workflows/steps/index.js
@@ -1606,27 +1606,14 @@ ${chalk.green(log)}`);
 		return util
 			.prompt([
 				{
-					type: "confirm",
-					name: "hasId",
-					message: "Do you have a LK ID?",
-					default: false
+					type: "input",
+					name: "id",
+					message:
+						"What is the LeanKit card id? (leave empty to skip)"
 				}
 			])
-			.then(answers => {
-				if (answers.hasId) {
-					return util
-						.prompt([
-							{
-								type: "input",
-								name: "id",
-								message: "What is your LK ID?"
-							}
-						])
-						.then(response => {
-							state.lkId = response.id.trim();
-							return Promise.resolve();
-						});
-				}
+			.then(response => {
+				state.lkId = response.id ? response.id.trim() : "";
 				return Promise.resolve();
 			});
 	},


### PR DESCRIPTION
### Short description of the work completed

> Reduced he LK id questions into a single question to reduce the amount of keyboard interactions from the user

### Steps to test (if not obvious)

1. just do a normal `tag-release dev`
2. should be able to just skip the question by entering nothing or enter a value and it use that value for the LK id

### For Reviewer Use Only

- [x] Code Reviewed
- [x] Tests Passed
- [x] Coverage Reviewed
- [x] Feature worked as expected
- [x] Updated `src/help.js` and `README.md`
- [x] Is the version upgrade path clear for this change? (breaking vs minor vs
  patch)
- [x] Follow up work tracked in a card if needed